### PR TITLE
fix: only filter flow nodes on type

### DIFF
--- a/titleBoundary/helpers.js
+++ b/titleBoundary/helpers.js
@@ -4,7 +4,7 @@
 const updateDrawBoundaryNodeData = (flowData) => {
   let newFlowData = flowData;
   Object.entries(flowData)
-    .filter(([_nodeId, nodeData]) => nodeData["type"] === 10 && nodeData["data"] !== defaultDrawBoundaryNodeData)
+    .filter(([_nodeId, nodeData]) => nodeData["type"] === 10)
     .forEach(([drawBoundaryNodeId, _drawBoundaryNodeData]) => newFlowData[drawBoundaryNodeId]["data"] = defaultDrawBoundaryNodeData);
   return newFlowData;
 }
@@ -12,7 +12,7 @@ const updateDrawBoundaryNodeData = (flowData) => {
 const updatePropertyInformationNodeData = (flowData) => {
   let newFlowData = flowData;
   Object.entries(flowData)
-    .filter(([_nodeId, nodeData]) => nodeData["type"] === 12 && nodeData["data"] !== defaultPropertyInformationNodeData)
+    .filter(([_nodeId, nodeData]) => nodeData["type"] === 12)
     .forEach(([propertyInfoNodeId, _propertyInfoNodeData]) => newFlowData[propertyInfoNodeId]["data"] = defaultPropertyInformationNodeData);
   return newFlowData;
 }


### PR DESCRIPTION
Addresses feedback: 
> I think the second clause in the filters for updateDrawBoundaryNodeData() and updatePropertyInformationNodeData() checking nodeData["data"] value are redundant - both objects will always be different objects in memory and the clause will always resolve to true. We can drop the clause, or if we want to check use another method to check equality.

Had originally added this clause thinking large flow updates would be slow & we don't want to waste time/double-update - but performance seems fine all around for our purposes here!