### PR TITLE
feat: add script for updating file passport variables

### DIFF
--- a/client.js
+++ b/client.js
@@ -62,7 +62,24 @@ class Client {
     if (errors || !data) throw new Error(formatJSON({ data, errors }));
     return { ...data };
   }
+
+  async updateFlow(flowId, liveFlowData) {
+    const { data, errors } = await this.graphQL(
+      `mutation UpdateFlow ($flowId: uuid!, $liveData: jsonb!) {
+        update_flows_by_pk(pk_columns: {id: $flowId}, _set: {data: $liveData}) {
+          id
+        }
+      }`,
+      {
+        flowId: flowId,
+        liveData: liveFlowData,
+      }
+    );
+    if (errors || !data) throw new Error(formatJSON({ data, errors }));
+    return { ...data };
+  }
 }
+
 
 function formatJSON({ data, errors }) {
   return JSON.stringify({ data, errors }, null, 2);

--- a/fileNames/helpers.js
+++ b/fileNames/helpers.js
@@ -112,7 +112,7 @@ const filesNowToNext = {
   "proposal.document.treeCanopyCalculator": "treeCanopyCalculator",
   "proposal.document.treesReport": "treesReport",
   "proposal.document.utilitiesStatement": "utilitiesStatement",
-  "proposal.document.utility.bill": "utilitiesBill",
+  "proposal.document.utility.bill": "utilityBill",
   "proposal.document.ventilationStatement": "ventilationStatement",
   "proposal.document.waterAndRecyclingStrategy": "wasteAndRecyclingStrategy",
   "proposal.document.waterEnvironmentAssessment": "waterEnvironmentAssessment",

--- a/fileNames/helpers.js
+++ b/fileNames/helpers.js
@@ -1,0 +1,118 @@
+/**
+ * Find each FileUpload node in a flow (live or published) and update its' passport variable (fn)
+ */
+const updateUploadNodeFn = (flowData) => {
+  let newFlowData = flowData;
+  Object.entries(flowData)
+    .filter(([_nodeId, nodeData]) => nodeData["type"] === 140)
+    .forEach(([uploadNodeId, uploadNodeData]) => {
+      const currentFn = uploadNodeData["data"]["fn"];
+      if (existingFns.includes(currentFn)) {
+        newFlowData[uploadNodeId]["data"]["fn"] = filesNowToNext[currentFn];
+      }
+    });
+  return newFlowData;
+}
+
+/**
+ * Find each FileUploadAndLabel node in a flow (live or published) and update the passport variable (fn) of each of its' defined files
+ */
+const updateUploadAndLabelNodeFns = (flowData) => {
+  let newFlowData = flowData;
+  Object.entries(flowData)
+    .filter(([_nodeId, nodeData]) => nodeData["type"] === 145)
+    .forEach(([uploadAndLabelNodeId, uploadAndLabelNodeData]) => {
+      uploadAndLabelNodeData["data"]["fileTypes"].forEach((file, i) => {
+        const currentFn = file?.fn;
+        if (existingFns.includes(currentFn)) {
+          newFlowData[uploadAndLabelNodeId]["data"]["fileTypes"][i]["fn"] = filesNowToNext[currentFn];
+        }
+      });
+    });
+  return newFlowData;
+}
+
+const filesNowToNext = {
+  "applicant.disability.evidence": "disabilityExemptionEvidence",
+  "property.drawing.elevation": "elevations.existing",
+  "property.drawing.floorPlan": "floorPlan.existing",
+  "property.drawing.roofPlan": "roofPlan.existing",
+  "property.drawing.section": "sections.existing",
+  "property.drawing.sitePlan": "sitePlan.existing",
+  "property.drawing.usePlan": "usePlan.existing",
+  "property.photograph": "photographs.existing",
+  "proposal.document.affordableHousingStatement": "affordableHousingStatement",
+  "proposal.document.bankStatement": "bankStatement",
+  "proposal.document.basementImpact": "basementImpactStatement",
+  "proposal.document.buildingControl.certificate": "buildingControlCertificate",
+  "proposal.document.conditionSurvey": "conditionSurvey",
+  "proposal.document.construction.invoice": "constructionInvoice",
+  "proposal.document.contamination": "contaminationReport",
+  "proposal.document.councilTaxBill": "councilTaxBill",
+  "proposal.document.crimePreventionStrategy": "crimePreventionStrategy",
+  "proposal.document.declaration": "statuatoryDeclaration",
+  "proposal.document.designAndAccess": "designAndAccessStatement",
+  "proposal.document.ecologyReport": "ecologyReport",
+  "proposal.document.eia": "environmentalImpactAssessment",
+  "proposal.document.energyStatement": "energyStatement",
+  "proposal.document.fireSafety": "fireSafetyReport",
+  "proposal.document.floodRisk": "floodRiskAssessment",
+  "proposal.document.foulDrainage": "foulDrainageAssessment",
+  "proposal.document.heritageStatement": "heritageStatement",
+  "proposal.document.hydrologyReport": "hydrologyReport",
+  "proposal.document.internalElevations": "internalElevations",
+  "proposal.document.internalSections": "internalSections",
+  "proposal.document.landContaminationAssessment": "landContaminationAssessment",
+  "proposal.document.landscapeStrategy": "landscapeStrategy",
+  "proposal.document.lightingAssessment": "lightingAssessment",
+  "proposal.document.lvia": "landscapeAndVisualImpactAssessment",
+  "proposal.document.mineral.assessment": "mineralsAndWasteAssessment",
+  "proposal.document.mineral.bioAerosolAssessment": "bioaerosolAssessment",
+  "proposal.document.mineral.birdStrikeRiskManagementPlan": "birdstrikeRiskManagementPlan",
+  "proposal.document.mineral.boreholeOrTrialPitAnalysis": "boreholeOrTrialPitAnalysis",
+  "proposal.document.mineral.geoAssessment": "geodiversityAssessment",
+  "proposal.document.mineral.hydrologicalAssessment": "hydrologicalAssessment",
+  "proposal.document.mineral.litterVerminAndBirdControl": "litterVerminAndBirdControlDetails",
+  "proposal.document.mineral.mitigationAndMonitoring": "emissionsMitigationAndMonitoringScheme",
+  "proposal.document.mineral.storageTreatmentDisposal": "storageTreatmentAndWasteDisposalDetails",
+  "proposal.document.newDwellingSchedule": "newDwellingsSchedule",
+  "proposal.document.noise": "noiseAssessment",
+  "proposal.document.openSpaceAssessment": "openSpaceAssessment",
+  "proposal.document.other.evidence": "otherEvidence",
+  "proposal.document.other": "otherDocument",
+  "proposal.document.parkingPlan": "parkingPlan",
+  "proposal.document.planningStatement": "planningStatement",
+  "proposal.document.statementOfCommunityInvolvement": "statementOfCommunityInvolvement",
+  "proposal.document.sunAndDaylight": "sunlightAndDaylightReport",
+  "proposal.document.sustainabilityStatement": "sustainabilityStatement",
+  "proposal.document.tenancyAgreement": "tenancyAgreement",
+  "proposal.document.tenancyInvoice": "tenancyInvoice",
+  "proposal.document.townCentre.impactAssessment": "townCentreImpactAssessment",
+  "proposal.document.townCentre.sequentialAssessment": "townCentreSequentialAssessment",
+  "proposal.document.transport": "transportAssessment",
+  "proposal.document.travelPlan": "travelPlan",
+  "proposal.document.treeCanopyCalculator": "treeCanopyCalculator",
+  "proposal.document.treesReport": "treesReport",
+  "proposal.document.utilitiesStatement": "utilitiesStatement",
+  "proposal.document.utility.bill": "utilitiesBill",
+  "proposal.document.ventilationStatement": "ventilationStatement",
+  "proposal.document.waterAndRecyclingStrategy": "wasteAndRecyclingStrategy",
+  "proposal.document.waterEnvironmentAssessment": "waterEnvironmentAssessment",
+  "proposal.drawing.elevation": "elevations.proposed",
+  "proposal.drawing.floorPlan": "floorPlan.proposed",
+  "proposal.drawing.locationPlan": "locationPlan",
+  "proposal.drawing.other": "otherDrawing",
+  "proposal.drawing.roofPlan": "roofPlan.proposed",
+  "proposal.drawing.section": "sections.proposed",
+  "proposal.drawing.sitePlan": "sitePlan.proposed",
+  "proposal.drawing.streetScene": "streetScene",
+  "proposal.drawing.unitPlan": "unitPlan.proposed",
+  "proposal.drawing.usePlan": "usePlan.proposed",
+  "proposal.photograph.evidence": "photographs.proposed",
+  "proposal.photograph": "photographs.proposed",
+  "proposal.visualisation": "visualisations"
+};
+
+const existingFns = Object.keys(filesNowToNext);
+
+module.exports = { updateUploadNodeFn, updateUploadAndLabelNodeFns };

--- a/fileNames/helpers.js
+++ b/fileNames/helpers.js
@@ -32,6 +32,24 @@ const updateUploadAndLabelNodeFns = (flowData) => {
   return newFlowData;
 }
 
+/**
+ * Find each TextInput (110) or DateInput (120) node in a flow (live or published) that asks about what a file contains and update its' passport variable (fn)
+ */
+const updateTextAndDateInputNodeFns = (flowData) => {
+  let newFlowData = flowData;
+  Object.entries(flowData)
+    .filter(([_nodeId, nodeData]) => nodeData["type"] === 110 || nodeData["type"] === 120)
+    .forEach(([inputNodeId, inputNodeData]) => {
+      const currentFn = inputNodeData["data"]["fn"];
+      existingFns.forEach((existingFn) => {
+        if (currentFn?.startsWith(existingFn)) {
+          newFlowData[inputNodeId]["data"]["fn"] = currentFn.replace(existingFn, filesNowToNext[existingFn]);
+        }
+      });
+    });
+  return newFlowData;
+}
+
 const filesNowToNext = {
   "applicant.disability.evidence": "disabilityExemptionEvidence",
   "property.drawing.elevation": "elevations.existing",
@@ -50,7 +68,7 @@ const filesNowToNext = {
   "proposal.document.contamination": "contaminationReport",
   "proposal.document.councilTaxBill": "councilTaxBill",
   "proposal.document.crimePreventionStrategy": "crimePreventionStrategy",
-  "proposal.document.declaration": "statuatoryDeclaration",
+  "proposal.document.declaration": "statutoryDeclaration",
   "proposal.document.designAndAccess": "designAndAccessStatement",
   "proposal.document.ecologyReport": "ecologyReport",
   "proposal.document.eia": "environmentalImpactAssessment",
@@ -115,4 +133,4 @@ const filesNowToNext = {
 
 const existingFns = Object.keys(filesNowToNext);
 
-module.exports = { updateUploadNodeFn, updateUploadAndLabelNodeFns };
+module.exports = { updateUploadNodeFn, updateUploadAndLabelNodeFns, updateTextAndDateInputNodeFns };

--- a/fileNames/index.js
+++ b/fileNames/index.js
@@ -1,0 +1,86 @@
+const ask = require("prompt");
+const chalk = require("chalk");
+const Client = require("../client");
+
+const { setupPrompts } = require("../prompts");
+const { updateUploadNodeFn, updateUploadAndLabelNodeFns } = require("./helpers");
+
+ask.start();
+
+(async function go() {
+  // greeting
+  console.log(
+    chalk.cyan(
+      `Hello! These prompts will step you through bulk updating Planx passport variables for files.\nType values when prompted or click 'enter' to accept ${chalk.white(
+        "(default)"
+      )} values.\n~~~~~~~~~~~~~~ ${chalk.bold("LET'S START")} ~~~~~~~~~~~~~~`
+    )
+  );
+
+  // authentication & setup
+  const { hasuraEnvironment, hasuraSecret, flowSlug } = await ask.get(
+    setupPrompts
+  );
+  const url = {
+    production: "https://hasura.editor.planx.uk/v1/graphql",
+    staging: "https://hasura.editor.planx.dev/v1/graphql",
+    local: "http://localhost:7100/v1/graphql",
+  };
+
+  // create graphQL client
+  const client = new Client({
+    hasuraSecret,
+    targetURL: url[hasuraEnvironment],
+  });
+
+  const formattedSlug = flowSlug.toLowerCase().trim().replaceAll(" ", "-");
+
+  // Fetch flows matching slugs
+  const flows = await client.getFlowData(formattedSlug);
+  if (flows?.length > 0) {
+    console.log(chalk.white(`Fetched ${flows.length} flows`));
+
+    flows.forEach(async (flow, i) => {
+      let liveFlowData;
+      let publishedFlowData;
+      let response;
+
+      try {        
+        // Only proceed with migration for flows that are published
+        if (flow.publishedFlows.length > 0) {
+          console.log(chalk.white(`Updating flow ${i+1}/${flows.length}: ${flow.team.slug}/${flow.slug}`));
+
+          // Find Upload & UploadAndLabel nodes in live flow data, update them
+          //   This does NOT require a corresponding operation because we are not creating the flow for the first time
+          liveFlowData = updateUploadNodeFn(flow.data);
+          liveFlowData = updateUploadAndLabelNodeFns(liveFlowData);
+  
+          // Find Upload & UploadAndLabel nodes in published flow data, update them directly too
+          publishedFlowData = updateUploadNodeFn(flow.publishedFlows?.[0]?.data);
+          publishedFlowData = updateUploadAndLabelNodeFns(publishedFlowData);
+  
+          // Write update in a single mutation block for postgres transaction-like rollback behavior on error
+          response = await client.updateFlowAndPublishedFlow(flow.id, liveFlowData, flow.publishedFlows?.[0]?.id, publishedFlowData);
+          if (response?.update_flows_by_pk?.id) {
+            console.log(
+              chalk.green(`Successfully updated live flow: ${flow.team.slug}/${flow.slug}`)
+            );
+          }
+          if (response?.update_published_flows_by_pk?.id) {
+            console.log(
+              chalk.green(`Successfully updated published version of flow: ${flow.team.slug}/${flow.slug}`)
+            );
+          }
+        } else {
+          console.log(
+            chalk.red(`Flow ${flow.team.slug}/${flow.slug} is not published, skipping migration. Please update manually in Editor`)
+          );
+        }
+      } catch (error) {
+        console.log(chalk.red(error));
+      }
+    });
+  } else {
+    console.log(chalk.red(`Cannot find any flows matching slug: ${formattedSlug}. Exiting migration script`));
+  }
+})();

--- a/fileNames/index.js
+++ b/fileNames/index.js
@@ -3,7 +3,7 @@ const chalk = require("chalk");
 const Client = require("../client");
 
 const { setupPrompts } = require("../prompts");
-const { updateUploadNodeFn, updateUploadAndLabelNodeFns } = require("./helpers");
+const { updateUploadNodeFn, updateUploadAndLabelNodeFns, updateTextAndDateInputNodeFns } = require("./helpers");
 
 ask.start();
 
@@ -46,24 +46,26 @@ ask.start();
       let response;
 
       try {        
-        // Only proceed with migration for flows that are published
         if (flow.publishedFlows.length > 0) {
-          console.log(chalk.white(`Updating flow ${i+1}/${flows.length}: ${flow.team.slug}/${flow.slug}`));
+          // Proceed with migration for flows that are published
+          console.log(chalk.white(`Updating published flow ${i+1}/${flows.length}: ${flow.team.slug}/${flow.slug}`));
 
           // Find Upload & UploadAndLabel nodes in live flow data, update them
           //   This does NOT require a corresponding operation because we are not creating the flow for the first time
           liveFlowData = updateUploadNodeFn(flow.data);
           liveFlowData = updateUploadAndLabelNodeFns(liveFlowData);
+          liveFlowData = updateTextAndDateInputNodeFns(liveFlowData);
   
           // Find Upload & UploadAndLabel nodes in published flow data, update them directly too
           publishedFlowData = updateUploadNodeFn(flow.publishedFlows?.[0]?.data);
           publishedFlowData = updateUploadAndLabelNodeFns(publishedFlowData);
+          publishedFlowData = updateTextAndDateInputNodeFns(publishedFlowData);
   
           // Write update in a single mutation block for postgres transaction-like rollback behavior on error
           response = await client.updateFlowAndPublishedFlow(flow.id, liveFlowData, flow.publishedFlows?.[0]?.id, publishedFlowData);
           if (response?.update_flows_by_pk?.id) {
             console.log(
-              chalk.green(`Successfully updated live flow: ${flow.team.slug}/${flow.slug}`)
+              chalk.green(`Successfully updated flow: ${flow.team.slug}/${flow.slug}`)
             );
           }
           if (response?.update_published_flows_by_pk?.id) {
@@ -72,9 +74,22 @@ ask.start();
             );
           }
         } else {
-          console.log(
-            chalk.red(`Flow ${flow.team.slug}/${flow.slug} is not published, skipping migration. Please update manually in Editor`)
-          );
+          // Proceed with migration for flows that are not published
+          console.log(chalk.white(`Updating unpublished flow ${i+1}/${flows.length}: ${flow.team.slug}/${flow.slug}`));
+
+          // Find Upload & UploadAndLabel nodes in live flow data, update them
+          //   This does NOT require a corresponding operation because we are not creating the flow for the first time
+          liveFlowData = updateUploadNodeFn(flow.data);
+          liveFlowData = updateUploadAndLabelNodeFns(liveFlowData);
+          liveFlowData = updateTextAndDateInputNodeFns(liveFlowData);
+  
+          // Write update
+          response = await client.updateFlow(flow.id, liveFlowData);
+          if (response?.update_flows_by_pk?.id) {
+            console.log(
+              chalk.green(`Successfully updated flow: ${flow.team.slug}/${flow.slug}`)
+            );
+          }
         }
       } catch (error) {
         console.log(chalk.red(error));

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
+    "start:fileNames": "node fileNames/index.js",
     "start:titleBoundary": "node titleBoundary/index.js",
     "precommit": "prettier --write **/*.js && git add ."
   },


### PR DESCRIPTION
For Upload & UploadAndLabel component types, we want to replace their passport variables based on a lookup list. In cases of UploadAndLabel, rules _should not_ be impacted, only the passport variable or "data field" for each document slot.

Test: 
- `pnpm start:fileNames`
- Try it locally against a flow like `opensystemslab/prior-approval-files`