### PR TITLE
January 2025 scripts: session revision

### DIFF
--- a/jan2025_revisedSessions/README.md
+++ b/jan2025_revisedSessions/README.md
@@ -1,0 +1,60 @@
+## January 2025
+
+Builds on the `/dec2024` scripts, but this time with changes that rely on a new release of the ODP Schema (v0.7.2). 
+
+See https://docs.google.com/spreadsheets/d/1Vtxp5BLweDPDooQoNhgOCYjCIBPRYIcOuyArGJRqOkI/edit?gid=0#gid=0
+
+### Running script
+
+Runs on node v18
+
+#### Locally
+
+Ensure your planx-new docker container is running locally.
+
+Populate the table `temp_data_migrations_audit` with flows, for example:
+
+```psql
+INSERT INTO temp_data_migrations_audit (flow_id, team_id)
+SELECT id, team_id
+FROM flows 
+WHERE team_id IN (1,2,3); 
+```
+
+Then run the script, which will fetch & update a flow from the audit table which has not been `updated` yet.
+
+```sh
+cd jan2025
+HASURA_ENV=local HASURA_SECRET=secret node index.js
+```
+
+#### Scheduled via crontab
+
+Populate the table `temp_data_migrations_audit` on staging or production.
+
+Crontab is a very rudimentry tool but worked smoothly & Hasura remained healthy at this pace!
+
+```sh
+# m h  dom mon dow   command
+*/1 * * * * HASURA_ENV=staging HASURA_SECRET=secret /home/user/.nvm/versions/node/v18.16.1/bin/node /path/to/planx-data-migrations/jan2025/index.js >> /path/to/Desktop/logs.txt 2>&1
+*/1 * * * * sleep 10; <repeat command above>
+*/1 * * * * sleep 20; <repeat command above>
+*/1 * * * * sleep 30; <repeat command above>
+*/1 * * * * sleep 40; <repeat command above>
+*/1 * * * * sleep 50; <repeat command above>
+```
+
+Console logs in the script are written to `/path/to/Desktop/logs.txt` for basic monitoring.
+
+```sh
+tail -f /path/to/Desktop/logs.txt
+``` 
+
+### Tests
+
+Basic unit tests are written with Node's native test runner. The mock data is especially useful to visualise the "old" content conditions in the editor and can be pasted directly in `flows.data` or `lowcal_sessions.data` respectively.
+
+```sh
+cd jan2025
+node --test
+```

--- a/jan2025_revisedSessions/client.js
+++ b/jan2025_revisedSessions/client.js
@@ -1,0 +1,87 @@
+require("isomorphic-fetch");
+
+class Client {
+  constructor({ hasuraSecret, targetURL }) {
+    this.secret = hasuraSecret;
+    this.url = targetURL;
+  }
+
+  async graphQL(query, variables) {
+    const result = await fetch(this.url, {
+      method: "POST",
+      body: JSON.stringify({ query, variables }),
+      headers: {
+        "x-hasura-admin-secret": this.secret,
+      },
+    });
+    return result.json();
+  }
+
+  async getQueuedFlow() {
+    const { data, errors } = await this.graphQL(
+      `query GetQueuedFlow {
+        temp_data_migrations_audit(
+          limit: 1, 
+          where: {updated: {_eq: false}}
+        ) {
+          id: flow_id
+          flow {
+            slug
+            team {
+              slug
+            }
+            sessions: lowcal_sessions(
+              where: {
+                created_at: {_gte: "2024-12-22"},
+                submitted_at: {_is_null: true}, 
+              }
+            ) {
+              id
+              data
+            }
+          }
+        }
+      }`
+    );
+
+    if (errors || !data) throw new Error(formatJSON({ data, errors }));
+    return data.temp_data_migrations_audit[0];
+  }
+
+  async updateSessionData(sessionId, sessionData) {
+    const { data, errors } = await this.graphQL(
+      `mutation UpdateLowcalSession ($id: uuid!, $data: jsonb!) {
+        update_lowcal_sessions_by_pk(pk_columns: {id: $id}, _set: {data: $data}) {
+          id
+        }
+      }`,
+      {
+        id: sessionId,
+        data: sessionData,
+      }
+    );
+    if (errors || !data) throw new Error(formatJSON({ data, errors }));
+    return { ...data };
+  }
+
+  async updateAuditTable(flowId) {
+    const { data, errors } = await this.graphQL(
+      `mutation UpdateFlow ($flowId: uuid!) {
+        update_temp_data_migrations_audit_by_pk(pk_columns: {flow_id: $flowId}, _set: {updated: true}) {
+          flow_id
+        }
+      }`,
+      {
+        flowId: flowId,
+      }
+    );
+    if (errors || !data) throw new Error(formatJSON({ data, errors }));
+    return { ...data };
+  }
+}
+
+function formatJSON({ data, errors }) {
+  return JSON.stringify({ data, errors }, null, 2);
+}
+
+module.exports = Client;

--- a/jan2025_revisedSessions/client.js
+++ b/jan2025_revisedSessions/client.js
@@ -26,6 +26,7 @@ class Client {
         ) {
           id: flow_id
           flow {
+            data
             slug
             team {
               slug

--- a/jan2025_revisedSessions/helpers.js
+++ b/jan2025_revisedSessions/helpers.js
@@ -1,0 +1,469 @@
+// Follows details outlined in gsheet here https://docs.google.com/spreadsheets/d/1Vtxp5BLweDPDooQoNhgOCYjCIBPRYIcOuyArGJRqOkI/edit?gid=0#gid=0
+const migrateFlowData = (flowData) => {
+  const timestamp = `[${new Date().toISOString().replace(/T/, ' ').replace(/\..+/, '')}]`;
+
+  let newFlowData = flowData;
+  let logs = "";
+
+  Object.entries(flowData).forEach(([nodeId, nodeData]) => {
+    // Flags
+    if (nodeData?.["type"] === 200) {
+      // Question or checklists with `flags` array
+      if (nodeData?.["data"]?.["flags"]?.length > 0) {
+        newFlowData[nodeId]["data"]["flags"] = nodeData["data"]["flags"].map(current =>
+          flagChanges[current]
+        );
+        logs += `${timestamp} Updated Question or Checklist flags (node ${nodeId}); `;
+      }
+
+      // Filter options with flag as `val`
+      const current = nodeData?.["data"]?.["val"];
+      if (current && Object.keys(flagChanges).includes(current)) {
+        const proposed = flagChanges[current];
+        newFlowData[nodeId]["data"]["val"] = proposed;
+
+        // Some flags also get updated `text`
+        if (proposed.endsWith(".consentNeeded")) {
+          newFlowData[nodeId]["data"]["text"] = "Consent needed";
+        }
+        if (proposed === "flag.wtt.notice") {
+          newFlowData[nodeId]["data"]["text"] = "Notice";
+        }
+        logs += `${timestamp} Updated Filter option flags (node ${nodeId}); `;
+      }
+    }
+
+    // Filter flagset category change
+    if (nodeData?.["type"] === 500 && nodeData?.["data"]?.["category"] === "Listed building consent") {
+      newFlowData[nodeId]["data"]["category"] = "Works to listed buildings";
+      logs += `${timestamp} Updated Filter category (node ${nodeId}); `;
+    }
+
+    // Result flagset category change and overrides flag references
+    if (nodeData?.["type"] === 3) {
+      if (nodeData?.["data"]?.["flagSet"] === "Listed building consent") {
+        newFlowData[nodeId]["data"]["flagSet"] = "Works to listed buildings";
+        logs += `${timestamp} Updated Result flagset (node ${nodeId}); `;
+      }
+
+      Object.keys(nodeData?.["data"]?.["overrides"] || {})?.map((current) => {
+        if (Object.keys(flagChanges).includes(current)) {
+          const proposed = flagChanges[current];
+          newFlowData[nodeId]["data"]["overrides"][proposed] = nodeData["data"]["overrides"][current];
+          delete newFlowData[nodeId]["data"]["overrides"][current];
+          logs += `${timestamp} Updated Result overrides (node ${nodeId}); `;
+        }
+      });
+    }
+
+    // Article 4s (options and selectable planning constraints)
+    if (nodeData?.["type"] === 200 && nodeData?.["data"]?.["val"]?.startsWith("article4")) {
+      const current = nodeData["data"]["val"];
+      newFlowData[nodeId]["data"]["val"] = councilA4Changes[current] || nodeData["data"]["val"].replace("article4", "articleFour");
+      logs += `${timestamp} Updated article4 option val (node ${nodeId}); `;
+    }
+
+    if (
+      nodeData?.["type"] === 11 &&
+      (nodeData?.["data"]?.["dataValues"]?.includes("article4") || nodeData?.["data"]?.["dataValues"]?.includes("article4.caz"))
+    ) {
+      // councilA4Changes aren't configurable via modal so we just care about prefix replacement here
+      newFlowData[nodeId]["data"]["dataValues"] = nodeData["data"]["dataValues"].map(current => current.replace("article4", "articleFour"));
+      logs += `${timestamp} Updated planning constraints selectable data values (node ${nodeId}); `;
+    }
+
+    // Listed building grades (options only)
+    if (nodeData?.["type"] === 200 && nodeData?.["data"]?.["val"]?.startsWith("listed.")) {
+      const current = nodeData["data"]["val"];
+      newFlowData[nodeId]["data"]["val"] = listedGradeChanges[current];
+      logs += `${timestamp} Updated listed building grade option val (node ${nodeId}); `;
+    }
+
+    // Flood risk zones (options only)
+    if (nodeData?.["type"] === 200 && nodeData?.["data"]?.["val"]?.startsWith("flood.")) {
+      const current = nodeData["data"]["val"];
+      newFlowData[nodeId]["data"]["val"] = floodZoneChanges[current];
+      logs += `${timestamp} Updated flood risk zone option val (node ${nodeId}); `;
+    }
+
+    // Property types (option or setvalue type)
+    if (
+      nodeData?.["data"]?.["val"] &&
+      Object.keys(propertyTypeChanges).includes(nodeData["data"]["val"])
+    ) {
+      const current = nodeData["data"]["val"];
+      newFlowData[nodeId]["data"]["val"] = propertyTypeChanges[current];
+      logs += `${timestamp} Updated property type value (node ${nodeId}); `
+    }
+
+    // Lingering draw boundary props in calculate formulas and defaults
+    if (nodeData?.["type"] === 700) {
+      Object.keys(nodeData?.["data"]?.["defaults"] || {})?.map((current) => {
+        if (Object.keys(drawBoundaryChanges).includes(current)) {
+          const proposed = drawBoundaryChanges[current];
+          newFlowData[nodeId]["data"]["defaults"][proposed] = nodeData["data"]["defaults"][current];
+          delete newFlowData[nodeId]["data"]["defaults"][current];
+          newFlowData[nodeId]["data"]["formula"] = nodeData["data"]["formula"].replaceAll(current, proposed);
+          logs += `${timestamp} Updated Calculate formula and defaults (node ${nodeId}); `;
+        }
+      });
+    }
+
+    // Lingering project types
+    if (nodeData?.["type"] === 200 && nodeData?.["data"]?.["val"] && Object.keys(projectTypeChanges).includes(nodeData["data"]["val"])) {
+      const current = nodeData["data"]["val"];
+      newFlowData[nodeId]["data"]["val"] = projectTypeChanges[current];
+      logs += `${timestamp} Updated project type value (node ${nodeId}); `;
+    }
+  });
+
+  return {
+    flowData: newFlowData,
+    logs: logs
+  };
+}
+
+const migrateSessionData = (sessionData) => {
+  const newsessionData = sessionData;
+
+  const passportData = sessionData?.passport?.data;
+  const breadcrumbs = sessionData?.breadcrumbs;
+
+  // Property types
+  if (Object.keys(passportData).includes("property.type")) {
+    newsessionData["passport"]["data"]["property.type"] = passportData["property.type"].map(
+      (current) => Object.keys(propertyTypeChanges).includes(current) ? propertyTypeChanges[current] : current
+    );
+
+    Object.entries(breadcrumbs).forEach(([nodeId, crumb]) => {
+      if (crumb.data?.hasOwnProperty("property.type")) {
+        newsessionData["breadcrumbs"][nodeId]["data"]["property.type"] = crumb["data"]["property.type"].map(
+          (current) => Object.keys(propertyTypeChanges).includes(current) ? propertyTypeChanges[current] : current
+        );
+      }
+    });
+  }
+
+  // Planning constraints (including `_constraints` audit key)
+  const combinedConstraintChanges = { ...listedGradeChanges, ...floodZoneChanges, ...councilA4Changes };
+  if (Object.keys(passportData).includes("property.constraints.planning") || Object.keys(passportData).includes("_nots")) {
+    newsessionData["passport"]["data"]["property.constraints.planning"] = passportData?.["property.constraints.planning"]?.map(
+      (current) => Object.keys(combinedConstraintChanges).includes(current) ? combinedConstraintChanges[current] : current.replaceAll("article4", "articleFour")
+    );
+    newsessionData["passport"]["data"]["_nots"]["property.constraints.planning"] = passportData?.["_nots"]?.["property.constraints.planning"]?.map(
+      (current) => Object.keys(combinedConstraintChanges).includes(current) ? combinedConstraintChanges[current] : current.replaceAll("article4", "articleFour")
+    );
+
+    Object.entries(breadcrumbs).forEach(([nodeId, crumb]) => {
+      if (crumb.data?.hasOwnProperty("property.constraints.planning")) {
+        newsessionData["breadcrumbs"][nodeId]["data"]["property.constraints.planning"] = crumb["data"]["property.constraints.planning"].map(
+          (current) => Object.keys(combinedConstraintChanges).includes(current) ? combinedConstraintChanges[current] : current.replaceAll("article4", "articleFour")
+        );
+      }
+      if (crumb.data?.hasOwnProperty("_nots")) {
+        newsessionData["breadcrumbs"][nodeId]["data"]["_nots"]["property.constraints.planning"] = crumb["data"]["_nots"]["property.constraints.planning"].map(
+          (current) => Object.keys(combinedConstraintChanges).includes(current) ? combinedConstraintChanges[current] : current.replaceAll("article4", "articleFour")
+        );
+      }
+    });
+  }
+
+  if (Object.keys(passportData).includes("_constraints")) {
+    // _constraints is a list of two requests: planning data first, os roads second
+    const planningDataConstraints = passportData["_constraints"][0]["constraints"];
+    Object.entries(planningDataConstraints).forEach(([currentKey, currentData]) => {
+      if (Object.keys(combinedConstraintChanges).includes(currentKey)) {
+        const proposedKey = combinedConstraintChanges[currentKey];
+        currentData["fn"] = proposedKey;
+        newsessionData["passport"]["data"]["_constraints"][0]["constraints"][proposedKey] = currentData;
+        delete newsessionData["passport"]["data"]["_constraints"][0]["constraints"][currentKey];
+
+        Object.entries(breadcrumbs).forEach(([nodeId, crumb]) => {
+          if (crumb.data?.hasOwnProperty("_constraints")) {
+            newsessionData["breadcrumbs"][nodeId]["data"]["_constraints"][0]["constraints"][proposedKey] = currentData;
+            delete newsessionData["breadcrumbs"][nodeId]["data"]["_constraints"][0]["constraints"][currentKey];
+          }
+        });
+      }
+
+      if (currentKey.includes("article4")) {
+        const proposedKey = currentKey.replaceAll("article4", "articleFour");
+        currentData["fn"] = proposedKey;
+        newsessionData["passport"]["data"]["_constraints"][0]["constraints"][proposedKey] = currentData;
+        delete newsessionData["passport"]["data"]["_constraints"][0]["constraints"][currentKey];
+
+        Object.entries(breadcrumbs).forEach(([nodeId, crumb]) => {
+          if (crumb.data?.hasOwnProperty("_constraints")) {
+            newsessionData["breadcrumbs"][nodeId]["data"]["_constraints"][0]["constraints"][proposedKey] = currentData;
+            delete newsessionData["breadcrumbs"][nodeId]["data"]["_constraints"][0]["constraints"][currentKey];
+          }
+        });
+      }
+    });
+
+    const planningDataMetadata = passportData["_constraints"][0]["metadata"];
+    Object.entries(planningDataMetadata).forEach(([currentKey, currentData]) => {
+      // A4 is only relevant constraint in metadata
+      if (currentKey.includes("article4")) {
+        const proposedKey = currentKey.replaceAll("article4", "articleFour");
+        newsessionData["passport"]["data"]["_constraints"][0]["metadata"][proposedKey] = currentData;
+        delete newsessionData["passport"]["data"]["_constraints"][0]["metadata"][currentKey];
+
+        Object.entries(breadcrumbs).forEach(([nodeId, crumb]) => {
+          if (crumb.data?.hasOwnProperty("_constraints")) {
+            newsessionData["breadcrumbs"][nodeId]["data"]["_constraints"][0]["metadata"][proposedKey] = currentData;
+            delete newsessionData["breadcrumbs"][nodeId]["data"]["_constraints"][0]["metadata"][currentKey];
+          }
+        });
+      }
+    });
+  }
+
+  return newsessionData;
+}
+
+const flagChanges = {
+  "IMMUNE": "flag.pp.immune",
+  "MISSING_INFO": "flag.pp.missingInfo",
+  "PLANNING_PERMISSION_REQUIRED": "flag.pp.permissionNeeded",
+  "PRIOR_APPROVAL": "flag.pp.priorApproval",
+  "PP-NOTICE": "flag.pp.notice",
+  "NO_APP_REQUIRED": "flag.pp.permittedDevelopment",
+  "PP-NOT_DEVELOPMENT": "flag.pp.notDevelopment",
+  "LB-MISSING_INFO": "flag.lbc.missingInfo",
+  "LB-REQUIRED": "flag.lbc.consentNeeded",
+  "LB-DE_MINIMIS": "flag.lbc.deMinimis",
+  "LB-NOT_REQUIRED": "flag.lbc.notRequired",
+  "TR-MISSING_INFO": "flag.wtt.missingInfo",
+  "TR-REQUIRED": "flag.wtt.consentNeeded",
+  "TR-DE_MINIMIS": "flag.wtt.notice",
+  "TR-NOT_REQUIRED": "flag.wtt.notRequired",
+  "DC-MISSING_INFO": "flag.dca.missingInfo",
+  "DC-REQUIRED": "flag.dca.consentNeeded",
+  "DC-DE_MINIMIS": "flag.dca.deMinimis",
+  "DC-NOT_REQUIRED": "flag.dca.notRequired",
+  "PO_MISSING_INFO": "flag.planningPolicy.missingInfo",
+  "LIKELY_FAIL": "flag.planningPolicy.fail",
+  "EDGE_CASE": "flag.planningPolicy.edgeCase",
+  "LIKELY_PASS": "flag.planningPolicy.pass",
+  "CO_MISSING_INFO": "flag.cil.missingInfo",
+  "CO_EXEMPTION_VOID": "flag.cil.exemptionVoid",
+  "CO_EXEMPT": "flag.cil.exempt",
+  "CO_RELIEF_VOID": "flag.cil.reliefVoid",
+  "CO_RELIEF": "flag.cil.relief",
+  "CO_LIABLE": "flag.cil.liable",
+  "CO_NOT_LIABLE": "flag.cil.notLiable",
+  "MCOU_TRUE": "flag.mcou.true",
+  "MCOU_FALSE": "flag.mcou.false",
+};
+
+const listedGradeChanges = {
+  "listed.grade.I": "listed.gradeOne",
+  "listed.grade.II": "listed.gradeTwo",
+  "listed.grade.II*": "listed.gradeTwoStar",
+};
+
+const floodZoneChanges = {
+  "flood.zone.1": "flood.zoneOne",
+  "flood.zone.2": "flood.zoneTwo",
+  "flood.zone.2.a": "flood.zoneTwo.a",
+  "flood.zone.2.b": "flood.zoneTwo.b",
+  "flood.zone.3": "flood.zoneThree",
+  "flood.zone.3.a": "flood.zoneThree.a",
+  "flood.zone.3.b": "flood.zoneThree.b",
+};
+
+const councilA4Changes = {
+  "article4.barnet.hendonBurroughs.1": "articleFour.barnet.hendonBurroughs.one",
+  "article4.barnet.hendonBurroughs.2": "articleFour.barnet.hendonBurroughs.two",
+  "article4.buckinghamshire.DO10fulmer": "articleFour.buckinghamshire.DOTenfulmer",
+  "article4.buckinghamshire.eastamershamroadOS0006": "articleFour.buckinghamshire.eastamershamroadOSZeroZeroZeroSix",
+  "article4.buckinghamshire.eastamershamroadOS9269": "articleFour.buckinghamshire.eastamershamroadOSNineTwoSixNine",
+  "article4.buckinghamshire.northA404": "articleFour.buckinghamshire.northAFourZeroFour",
+  "article4.buckinghamshire.os1178": "articleFour.buckinghamshire.osOneOneSevenEight",
+  "article4.buckinghamshire.os262": "articleFour.buckinghamshire.osTwoSixTwo",
+  "article4.buckinghamshire.os3100": "articleFour.buckinghamshire.osThreeOneZeroZero",
+  "article4.buckinghamshire.os3313.a": "articleFour.buckinghamshire.osThreeThreeOneThree.a",
+  "article4.buckinghamshire.os3313.b": "articleFour.buckinghamshire.osThreeThreeOneThree.b",
+  "article4.buckinghamshire.os4729": "articleFour.buckinghamshire.osFourSevenTwoNine",
+  "article4.buckinghamshire.os5200": "articleFour.buckinghamshire.osFiveTwoZeroZero",
+  "article4.buckinghamshire.os6961": "articleFour.buckinghamshire.osSixNineSixOne",
+  "article4.buckinghamshire.os8050": "articleFour.buckinghamshire.osEightZeroFiveZero",
+  "article4.buckinghamshire.os8349": "articleFour.buckinghamshire.osEightThreeFourNine",
+  "article4.buckinghamshire.southA413": "articleFour.buckinghamshire.southAFourOneThree",
+  "article4.buckinghamshire.southpenfoldlaneOS262": "articleFour.buckinghamshire.southpenfoldlaneOSTwoSixThree",
+  "article4.camden.147kentishTown": "articleFour.camden.oneFourSevenKentishTown",
+  "article4.camden.187kentishTown": "articleFour.camden.oneEightSevenKentishTown",
+  "article4.camden.33yorkRise": "articleFour.camden.threeThreeYorkRise",
+  "article4.camden.eC3Caz": "articleFour.camden.eCThreeCaz",
+  "article4.camden.eC3NoCaz": "articleFour.camden.eCThreeNoCaz",
+  "article4.camden.suiGenC3": "articleFour.camden.suiGenCThree",
+  "article4.gateshead.saltwell.D1": "articleFour.gateshead.saltwell.dOne",
+  "article4.gateshead.saltwell.D2": "articleFour.gateshead.saltwell.dTwo",
+  "article4.gateshead.saltwell.D3": "articleFour.gateshead.saltwell.dThree",
+  "article4.gateshead.saltwell.D4": "articleFour.gateshead.saltwell.dFour",
+  "article4.gateshead.saltwell.D5": "articleFour.gateshead.saltwell.dFive",
+  "article4.medway.historicRochester.1": "articleFour.medway.historicRochester.one",
+  "article4.medway.historicRochester.2": "articleFour.medway.historicRochester.two",
+  "article4.medway.historicRochester.3": "articleFour.medway.historicRochester.three",
+  "article4.medway.historicRochester.4": "articleFour.medway.historicRochester.four",
+  "article4.medway.historicRochester.5": "articleFour.medway.historicRochester.five",
+  "article4.medway.historicRochester.6": "articleFour.medway.historicRochester.six",
+  "article4.medway.historicRochester.7": "articleFour.medway.historicRochester.seven",
+  "article4.medway.historicRochester.8": "articleFour.medway.historicRochester.eight",
+  "article4.medway.historicRochester.9": "articleFour.medway.historicRochester.nine",
+  "article4.medway.historicRochester.10": "articleFour.medway.historicRochester.ten",
+  "article4.medway.historicRochester.11": "articleFour.medway.historicRochester.eleven",
+  "article4.medway.historicRochester.12": "articleFour.medway.historicRochester.twelve",
+  "article4.medway.historicRochester.13": "articleFour.medway.historicRochester.thirteen",
+  "article4.medway.historicRochester.14": "articleFour.medway.historicRochester.fourteen",
+  "article4.medway.newRoad.1": "articleFour.medway.newRoad.one",
+  "article4.medway.newRoad.2": "articleFour.medway.newRoad.two",
+  "article4.medway.newRoad.3": "articleFour.medway.newRoad.three",
+  "article4.medway.newRoad.4": "articleFour.medway.newRoad.four",
+  "article4.medway.upperBush.1": "articleFour.medway.upperBush.one",
+  "article4.medway.upperBush.2": "articleFour.medway.upperBush.two",
+  "article4.medway.upperBush.3": "articleFour.medway.upperBush.three",
+  "article4.medway.upperBush.4": "articleFour.medway.upperBush.four",
+  "article4.medway.upperUpnor.1": "articleFour.medway.upperUpnor.one",
+  "article4.medway.upperUpnor.2": "articleFour.medway.upperUpnor.two",
+  "article4.medway.upperUpnor.3": "articleFour.medway.upperUpnor.three",
+  "article4.medway.upperUpnor.4": "articleFour.medway.upperUpnor.four",
+  "article4.medway.upperUpnor.5": "articleFour.medway.upperUpnor.five",
+  "article4.medway.upperUpnor.6": "articleFour.medway.upperUpnor.six",
+  "article4.medway.upperUpnor.7": "articleFour.medway.upperUpnor.seven",
+  "article4.medway.upperUpnor.8": "articleFour.medway.upperUpnor.eight",
+  "article4.medway.upperUpnor.9": "articleFour.medway.upperUpnor.nine",
+  "article4.medway.upperUpnor.10": "articleFour.medway.upperUpnor.ten",
+  "article4.medway.upperUpnor.11": "articleFour.medway.upperUpnor.eleven",
+  "article4.newcastle.hmo1": "articleFour.newcastle.hmoOne",
+  "article4.newcastle.hmo2": "articleFour.newcastle.hmoTwo",
+  "article4.newcastle.hmo3": "articleFour.newcastle.hmoThree",
+  "article4.newcastle.northumberlandGardens2": "articleFour.newcastle.northumberlandGardens3",
+  "article4.newcastle.saintPetersBasin1": "articleFour.newcastle.saintPetersBasinOne",
+  "article4.newcastle.saintPetersBasin2": "articleFour.newcastle.saintPetersBasinTwo",
+  "article4.newcastle.saintPetersBasin3": "articleFour.newcastle.saintPetersBasinThree",
+  "article4.newcastle.saintPetersBasin4": "articleFour.newcastle.saintPetersBasinFour",
+  "article4.newcastle.saintPetersBasin5": "articleFour.newcastle.saintPetersBasinFive",
+  "article4.stAlbans.harpenden1": "articleFour.stAlbans.harpendenOne",
+  "article4.stAlbans.harpenden2": "articleFour.stAlbans.harpendenTwo",
+  "article4.stAlbans.kimptonBottom.1": "articleFour.stAlbans.kimptonBottom.one",
+  "article4.stAlbans.kimptonBottom.2": "articleFour.stAlbans.kimptonBottom.two",
+  "article4.stAlbans.landBetweenRaggedHallAndM10": "articleFour.stAlbans.landBetweenRaggedHallAndMTen",
+};
+
+const projectTypeChanges = {
+  "ChangeOfUse": "changeOfUse",
+  "alter.deck": "alter.decks",
+  "alter.internal.mezzanine": "internal.mezzanine",
+  "alter.internal.loft": "internal.loft",
+};
+
+const drawBoundaryChanges = {
+  "property.boundary.site": "proposal.site",
+  "property.boundary.site.buffered": "proposal.site.buffered",
+  "property.boundary.area": "proposal.site.area",
+  "property.boundary.area.hectares": "proposal.site.area.hectares",
+  "property.boundary.title": "property.boundary",
+  "property.boundary.title.area": "property.boundary.area",
+  "property.boundary.title.area.hectares": "property.boundary.area.hectares",
+};
+
+// See https://docs.google.com/spreadsheets/d/1P_MjwuJlTshSsz1-9yLjBtZOqim93y31AGglturIaJA/edit?gid=0#gid=0
+const propertyTypeChanges = {
+  "commercial.abattoir": "commercial.industrial.abattoir",
+  "commercial.ancilliary": "commercial",
+  "commercial.community.CCTV": "commercial.utility.CCTV",
+  "commercial.community.cemetary": "commercial.community.cemetery",
+  "commercial.community.cemetary.cemetary": "commercial.community.cemetery.cemetery",
+  "commercial.community.cemetary.chapelOfRest": "commercial.community.cemetery.chapelOfRest",
+  "commercial.community.cemetary.columbarium": "commercial.community.cemetery.columbarium",
+  "commercial.community.cemetary.columbarium": "commercial.community.cemetery.columbarium",
+  "commercial.community.cemetary.crematorium": "commercial.community.cemetery.crematorium",
+  "commercial.community.cemetary.military": "commercial.community.cemetery.military",
+  "commercial.education.secondarySchool": "commercial.education.school.secondary",
+  "commercial.education.secondarySchool.private": "commercial.education.school.secondary.private",
+  "commercial.education.secondarySchool.state": "commercial.education.school.secondary.state",
+  "commercial.fish.processing": "commercial.industrial.fishProcessing",
+  "commercial.horticulture": "commercial.agriculture.horticulture",
+  "commercial.horticulture.smallholding": "land.smallholding",
+  "commercial.horticulture.vineyard": "commercial.agriculture.horticulture.vineyard",
+  "commercial.horticulture.watercress": "commercial.agriculture.horticulture.watercress",
+  "commercial.industrial.distribution": "commercial.storage.distribution",
+  "commercial.industrial.distribution.solidFueld": "commercial.storage.distribution.solidFuel",
+  "commercial.industrial.distribution.timber": "commercial.storage.distribution.timber",
+  "commercial.industrial.light.storage": "commercial.storage",
+  "commercial.industrial.light.storage.crops": "commercial.storage.crops",
+  "commercial.industrial.light.storage.solidFuel": "commercial.storage.solidFuel",
+  "commercial.industrial.light.storage.timber": "commercial.storage.timber",
+  "commercial.information": "other.information",
+  "commercial.information.advertising": "other.information.advertising",
+  "commercial.information.tourist.sign": "other.information.touristSign",
+  "commercial.information.tourist.visitor": "commercial.retail.visitorInformation",
+  "commercial.information.traffic.sign": "other.information.trafficSign",
+  "commercial.leisure.sport.historicVehicles": "commercial.leisure.museum.historicVehicles",
+  "commercial.medical.care.home": "commercial.medical.careHome",
+  "commercial.medical.care.hospital": "commercial.medical.hospital",
+  "commercial.retail.atm": "commercial.utility.atm",
+  "commercial.storageLand": "commercial.storage.land",
+  "commercial.storageLand.building": "commercial.industrial.buildersYard",
+  "commercial.storageLand.general": "commercial.storage.land.general",
+  "commercial.transport.bus": "commercial.transport.road.bus",
+  "commercial.transport.dock": "commercial.transport.water.dock",
+  "commercial.transport.dock.ferry.passengers": "commercial.transport.water.dock.ferry.passengers",
+  "commercial.transport.dock.ferry.vehicles": "commercial.transport.water.dock.ferry.vehicles",
+  "commercial.transport.dock.generalBerth": "commercial.transport.water.dock.generalBerth",
+  "commercial.transport.dock.refuelling": "commercial.transport.water.dock.refuelling",
+  "commercial.transport.dock.slipway": "commercial.transport.water.dock.slipway",
+  "commercial.transport.dock.slipway": "commercial.transport.water.dock.passenger",
+  "commercial.transport.dock.tankerBerth": "commercial.transport.water.dock.tankerBerth",
+  "commercial.transport.infrastructure.aqueduct": "commercial.transport.water.infrastructure.aqueduct",
+  "commercial.transport.infrastructure.lock": "commercial.transport.water.infrastructure.lock",
+  "commercial.transport.infrastructure.weighing": "commercial.transport.road.infrastructure.weighing",
+  "commercial.transport.infrastructure.weir": "commercial.transport.water.infrastructure.weir",
+  "commercial.transport.marina": "commercial.transport.water.marina",
+  "commercial.transport.mooring": "commercial.transport.water.mooring",
+  "commercial.transport.overnightLorryPark": "commercial.transport.road.overnightLorryPark",
+  "commercial.transport.parking": "commercial.transport.road.parking",
+  "commercial.transport.parking.car": "commercial.transport.road.parking.car",
+  "commercial.transport.parking.coach": "commercial.transport.road.parking.coach",
+  "commercial.transport.parking.commercialVehicle": "commercial.transport.road.parking.commercialVehicle",
+  "commercial.transport.parking.parkAndRide": "commercial.transport.road.parking.parkAndRide",
+  "commercial.transport.railAsset": "commercial.transport.rail.railAsset",
+  "commercial.transport.storage": "commercial.storage.transport",
+  "commercial.transport.storage.boat": "commercial.storage.transport.boat",
+  "commercial.transport.storage.bus": "commercial.storage.transport.bus",
+  "commercial.transport.terminal.bus": "commercial.transport.road.terminal.bus",
+  "commercial.transport.terminal.train": "commercial.transport.rail.terminal",
+  "commercial.transport.terminal.vehicularRail": "commercial.transport.rail.terminal",
+  "commercial.transport.track": "commercial.transport.rail.track",
+  "commercial.transport.track.cliff": "commercial.transport.rail.track",
+  "commercial.transport.track.monorail": "commercial.transport.rail.monorail",
+  "land.agriculture": "commercial.agriculture.land",
+  "land.agriculture.crops": "commercial.agriculture.land.crops",
+  "land.agriculture.grazing": "commercial.agriculture.land.grazing",
+  "land.agriculture.orchard": "commercial.agriculture.land.orchard",
+  "land.building": "other.ancillary",
+  "land.building.aviary": "other.ancillary.aviary",
+  "land.building.bandstand": "other.ancillary.bandstand",
+  "land.building.pavilion": "other.ancillary.pavilion",
+  "land.building.sportsViewing": "other.ancillary.sportsViewing",
+  "residential.dwelling": "residential",
+  "residential.dwelling.boat": "residential.boat",
+  "residential.dwelling.caravan": "residential.caravan",
+  "residential.dwelling.flat": "residential.flat",
+  "residential.dwelling.flat.multiple": "residential.multiple",
+  "residential.dwelling.holiday": "residential.holiday",
+  "residential.dwelling.house": "residential.house",
+  "residential.dwelling.house.detached": "residential.house.detached",
+  "residential.dwelling.house.multiple": "residential.multiple",
+  "residential.dwelling.house.semiDetached": "residential.house.semiDetached",
+  "residential.dwelling.house.terrace": "residential.house.terrace",
+  "residential.dwelling.house.terrace.end": "residential.house.terrace.end",
+  "residential.dwelling.house.terrace.mid": "residential.house.terrace.mid",
+  "residential.dwelling.liveWork": "residential.liveWork",
+  "residential.dwelling.shelteredAccommodation": "residential.shelteredAccommodation",
+  "residential.HMO.student": "residential.student",
+};
+
+module.exports = { migrateFlowData, migrateSessionData };

--- a/jan2025_revisedSessions/index.js
+++ b/jan2025_revisedSessions/index.js
@@ -1,0 +1,70 @@
+const chalk = require("chalk");
+const Client = require("./client");
+const { migrateSessionData } = require("./helpers");
+
+const timestamp = `[${new Date().toISOString().replace(/T/, ' ').replace(/\..+/, '')}]`;
+
+(async function go() {
+  const url = {
+    production: "https://hasura.editor.planx.uk/v1/graphql",
+    staging: "https://hasura.editor.planx.dev/v1/graphql",
+    local: "http://localhost:7100/v1/graphql",
+  };
+
+  const hasuraSecret = process.env["HASURA_SECRET"];
+  const env = process.env["HASURA_ENV"];
+  console.log(chalk.cyan(`${timestamp} Connecting to Hasura ${env}`));
+
+  // Create GraphQL client
+  const client = new Client({
+    hasuraSecret,
+    targetURL: url[env],
+  });
+
+  // Get a queued flow that hasn't been updated yet
+  const { id, flow } = await client.getQueuedFlow();
+  const flowSlug = `${flow?.team?.slug}/${flow?.slug}`;
+
+  if (!id) return;
+  
+  if (id) {
+    try {
+      const isPublished = flow.publishedFlows?.length > 0;
+      const isPublishedWithSessions = isPublished && flow.sessions?.length > 0;
+
+      console.log(`${timestamp} Fetching flow ${flowSlug}`);
+
+      if (isPublishedWithSessions) {
+        // Iterate through sessions and update them individually if they have FindProperty or PlanningConstraints breadcrumb
+        for (const session of flow.sessions) {
+          const findPropertyNodeId = Object.entries(flow.data).find(([_nodeId, nodeData]) => nodeData.type === 9)?.[0];
+          const hasFindPropertyBreadcrumb = Object.keys(session.data?.breadcrumbs).includes(findPropertyNodeId);
+          const planningConstraintsNodeId = Object.entries(flow.data).find(([_nodeId, nodeData]) => nodeData.type === 11)?.[0];
+          const hasPlanningConstraintsBreadcrumb = Object.keys(session.data?.breadcrumbs).includes(planningConstraintsNodeId);
+
+          if (hasFindPropertyBreadcrumb || hasPlanningConstraintsBreadcrumb) {
+            console.log(`${timestamp} Updating session ${session.id} (${flowSlug})`);
+            const sessionData = migrateSessionData(session.data);
+
+            // Write session data to database
+            const sessionDataResponse = await client.updateSessionData(session.id, sessionData);
+            if (
+              sessionDataResponse?.update_lowcal_sessions_by_pk?.id
+            ) {
+              console.log(`${timestamp} Successfully updated session ${session.id} (${flowSlug})`);
+            }
+          } else {
+            console.log(`${timestamp} Skipping session without FindProperty or PlanningConstraints breadcrumb ${session.id} (${flowSlug})`);
+          }
+        };
+      } else {
+        console.log(`${timestamp} Skipping flow without active sessions ${flowSlug}`);
+      }
+
+      // Mark the audit table as "updated" once we've checked a flow regardless of finding sessions
+      const _auditTableResponse = await client.updateAuditTable(id);
+    } catch (error) {
+      console.log(chalk.red(`Error": ${error}`));
+    }
+  }
+})();

--- a/jan2025_revisedSessions/index.js
+++ b/jan2025_revisedSessions/index.js
@@ -22,19 +22,14 @@ const timestamp = `[${new Date().toISOString().replace(/T/, ' ').replace(/\..+/,
   });
 
   // Get a queued flow that hasn't been updated yet
-  const { id, flow } = await client.getQueuedFlow();
-  const flowSlug = `${flow?.team?.slug}/${flow?.slug}`;
-
-  if (!id) return;
-  
-  if (id) {
+  const { id, flow } = await client.getQueuedFlow();  
+  if (id && flow) {
     try {
-      const isPublished = flow.publishedFlows?.length > 0;
-      const isPublishedWithSessions = isPublished && flow.sessions?.length > 0;
-
+      const flowSlug = `${flow.team?.slug}/${flow.slug}`;
       console.log(`${timestamp} Fetching flow ${flowSlug}`);
 
-      if (isPublishedWithSessions) {
+      const hasSessions = flow.sessions?.length > 0;
+      if (hasSessions) {
         // Iterate through sessions and update them individually if they have FindProperty or PlanningConstraints breadcrumb
         for (const session of flow.sessions) {
           const findPropertyNodeId = Object.entries(flow.data).find(([_nodeId, nodeData]) => nodeData.type === 9)?.[0];

--- a/jan2025_revisedSessions/tests/flowData.test.js
+++ b/jan2025_revisedSessions/tests/flowData.test.js
@@ -1,0 +1,12 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const { migrateFlowData } = require("./../helpers");
+const { oldFlow } = require("./mocks/oldFlow");
+const { expectedFlow } = require("./mocks/expectedFlow");
+
+describe("migrate flow data function", () => {
+  it("#returns the expected data", () => {
+    const migratedFlow = migrateFlowData(oldFlow).flowData;
+    assert.deepStrictEqual(migratedFlow, expectedFlow);
+  });
+});

--- a/jan2025_revisedSessions/tests/mocks/expectedFlow.js
+++ b/jan2025_revisedSessions/tests/mocks/expectedFlow.js
@@ -1,0 +1,1706 @@
+const expectedFlow = {
+    "_root": {
+        "edges": [
+            "N8T7u2fedh",
+            "496NokZZcC",
+            "PXI9SWUFSM",
+            "9YqHTuXVjs",
+            "M25kTJaupX",
+            "594ajFBA8C",
+            "XDlfXlSFJY",
+            "0xIFi1ZhfZ",
+            "vEr4UyFu4u",
+            "Z9dOoU0dD1",
+            "MQzrk4KPRO",
+            "Result1",
+            "Result2"
+        ]
+    },
+    "Result1": {
+        "data": {
+            "flagSet": "Planning permission",
+            "overrides": {
+                "flag.pp.immune": {
+                    "heading": "It looks like this project may not need planning permission. However, planning conditions are not included in this service at the moment so you should always check with the council before doing any work.",
+                    "description": "This project happened long enough ago that it may not need planning permission. However, planning conditions are not included in this service at the moment so you should always check with the council before doing any work. We recommend applying for a Lawful Development Certificate. This will give you legal confirmation that the project does not need planning permission."
+                },
+                "flag.pp.notice": {
+                    "heading": "You need to tell us about the changes ",
+                    "description": "It looks like this project may not need planning permission. However, you must tell us about the changes in writing before starting work. "
+                },
+                "flag.pp.missingInfo": {
+                    "heading": "Missing information",
+                    "description": "We need some more information to find out whether your project needs planning permission."
+                },
+                "flag.pp.priorApproval": {
+                    "heading": "It looks like this project needs Prior Approval",
+                    "description": "Prior Approval means you may need to apply for approval from your local planning authority that specific parts of the development are acceptable before you start work."
+                },
+                "flag.pp.permittedDevelopment": {
+                    "heading": "It looks like this project does not need planning permission. ",
+                    "description": "This project may fall under permitted development, and therefore may not need planning permission. However, planning conditions are not included in this service at the moment. We recommend applying for a Lawful Development Certificate. This will give you legal confirmation that the project does not need planning permission."
+                },
+                "flag.pp.notDevelopment": {
+                    "heading": "It looks like this project does not need planning permission",
+                    "description": "This project may fall outside the legal definition of development and may not need planning permission. You can check this by applying for a Lawful Development Certificate before starting work, as there may be other things we need to check. This will give you legal confirmation that the project does not need planning permission."
+                },
+                "flag.pp.permissionNeeded": {
+                    "heading": "It looks like this project needs planning permission",
+                    "description": "Based on the information you have provided, this project needs planning permission. Continue to find out how to apply."
+                }
+            }
+        },
+        "type": 3
+    },
+    "Result2": {
+        "type": 3,
+        "data": {
+            "flagSet": "Works to listed buildings",
+            "overrides": {
+                "flag.lbc.consentNeeded": {
+                    "heading": "Custom heading when LBC is required"
+                }
+            }
+        }
+    },
+    "02aNXeNi17": {
+        "data": {
+            "val": "land.amenity.surface.pavement",
+            "text": "Pavement"
+        },
+        "type": 200
+    },
+    "0FIHMM1vcO": {
+        "data": {
+            "val": "flood.zoneTwo",
+            "text": "Zone 2 (Medium)"
+        },
+        "type": 200
+    },
+    "0xIFi1ZhfZ": {
+        "data": {
+            "fn": "property.constraints.planning",
+            "tags": [],
+            "text": "Do any of these constraints apply to you?",
+            "allRequired": false,
+            "neverAutoAnswer": false
+        },
+        "type": 105,
+        "edges": [
+            "tUsd2VX0CE",
+            "5NwXOe2kl6",
+            "1DMLC1ilHg",
+            "S50pYmgKlM"
+        ]
+    },
+    "13AhIhkjNx": {
+        "data": {
+            "fn": "property.type",
+            "text": "What type of religious property is it?"
+        },
+        "type": 100,
+        "edges": [
+            "Hx11x57Zy8",
+            "PNoPwbkS2L",
+            "HaOcUgqqqP",
+            "F7lubrvq95",
+            "YSoz99VKge",
+            "oIqbT6ofX4",
+            "pk3SFkfK0r",
+            "XrXi3rlRSZ",
+            "eR4Uk4wds5",
+            "LZ5owtXc8R",
+            "wkNZj4EJuR",
+            "ok2w6dmuEw",
+            "GF2Ubxttu3"
+        ]
+    },
+    "1DMLC1ilHg": {
+        "data": {
+            "val": "listed",
+            "text": "Listed building",
+            "flags": [
+                "flag.lbc.deMinimis"
+            ]
+        },
+        "type": 200,
+        "edges": [
+            "jtVZ3Xa3DE"
+        ]
+    },
+    "1ElP19Mpqq": {
+        "data": {
+            "fn": "property.type",
+            "info": "<p>This information helps your planning officer understand the site and the impact of the project. The type of property might affect what information you need to submit with your application. </p>",
+            "text": "What type of industrial property is it?"
+        },
+        "type": 100,
+        "edges": [
+            "nAQtDxo6c4",
+            "GJZ7xULXqK",
+            "NWT3CsFSCz",
+            "xHPFIDDV1V",
+            "J4IXSAlPTw"
+        ]
+    },
+    "1nHpe53Ytm": {
+        "data": {
+            "val": "commercial.community",
+            "text": "Institutions and community buildings"
+        },
+        "type": 200,
+        "edges": [
+            "XTgtfwSuLQ"
+        ]
+    },
+    "2FoekDHPbA": {
+        "data": {
+            "val": "articleFour.camden.oneFourSevenKentishTown",
+            "text": "Camden A4"
+        },
+        "type": 200
+    },
+    "2MlqAY7JKX": {
+        "data": {
+            "val": "commercial.medical.dentist",
+            "text": "Dentist"
+        },
+        "type": 200
+    },
+    "2Z4Ah7QPvE": {
+        "data": {
+            "val": "residential.flat",
+            "text": "Flat (or building containing flats)"
+        },
+        "type": 200
+    },
+    "3FiKmXz0Ct": {
+        "data": {
+            "val": "other.unsupported",
+            "text": "No, none of these"
+        },
+        "type": 200,
+        "edges": [
+            "hNvEwECRda"
+        ]
+    },
+    "3Pp2uvwRfG": {
+        "data": {
+            "val": "commercial.retail.fuel",
+            "text": "Fuel station"
+        },
+        "type": 200
+    },
+    "3TJYlfAUz6": {
+        "data": {
+            "val": "object.religious.building",
+            "text": "Place of worship"
+        },
+        "type": 200,
+        "edges": [
+            "13AhIhkjNx"
+        ]
+    },
+    "3lblfduLSS": {
+        "data": {
+            "fn": "property.type",
+            "val": "land",
+            "operation": "replace"
+        },
+        "type": 380
+    },
+    "3s74llQcam": {
+        "data": {
+            "val": "commercial.retail.drinking",
+            "text": "Public house, bar or nightclub"
+        },
+        "type": 200
+    },
+    "3uLzlsc0DS": {
+        "data": {
+            "val": "commercial.leisure.entertainment.theatre",
+            "text": "Theatre"
+        },
+        "type": 200
+    },
+    "3zhtpyYEE1": {
+        "data": {
+            "val": "articleFour.lambeth.HMO",
+            "text": "HMO"
+        },
+        "type": 200
+    },
+    "496NokZZcC": {
+        "type": 300,
+        "edges": [
+            "6689164d-2a5e-422f-8d6a-d3ea11a2fbb9"
+        ]
+    },
+    "4n7h4JzAJR": {
+        "data": {
+            "val": "commercial.retail.other",
+            "text": "Other"
+        },
+        "type": 200,
+        "edges": [
+            "UW5C3zLAVR"
+        ]
+    },
+    "4xoUWkORDG": {
+        "data": {
+            "val": "commercial.community.hall",
+            "text": "Community hall"
+        },
+        "type": 200
+    },
+    "594ajFBA8C": {
+        "data": {
+            "fn": "proposal.site.area.hectares.double",
+            "title": "Double the site boundary in hectares",
+            "formula": "proposal.site.area.hectares*2",
+            "defaults": {
+                "proposal.site.area.hectares": "0"
+            },
+            "formatOutputForAutomations": false
+        },
+        "type": 700
+    },
+    "5NwXOe2kl6": {
+        "data": {
+            "val": "designated",
+            "text": "Designated land",
+            "flags": [
+                "flag.pp.priorApproval",
+                "flag.dca.consentNeeded"
+            ]
+        },
+        "type": 200
+    },
+    "5TB6qVisoq": {
+        "data": {
+            "val": "flag.lbc.missingInfo",
+            "text": "Missing information"
+        },
+        "type": 200
+    },
+    "5lzcg8luJT": {
+        "data": {
+            "val": "commercial.utility",
+            "text": "Utility (water, waste, electricity)"
+        },
+        "type": 200
+    },
+    "5yGblc1zi8": {
+        "data": {
+            "val": "commercial.education.other",
+            "text": "Other educational establishment"
+        },
+        "type": 200
+    },
+    "6FL5k5zovo": {
+        "data": {
+            "text": "This flow always need to live between 'Find Property' and 'About the Property'."
+        },
+        "type": 100
+    },
+    "6IQpHgCEso": {
+        "data": {
+            "val": "commercial.retail.shop.gardenCentre",
+            "text": "Garden centre"
+        },
+        "type": 200
+    },
+    "6TxMlBZqzW": {
+        "data": {
+            "val": "commercial.transport.road.terminal.bus",
+            "text": "Bus station"
+        },
+        "type": 200
+    },
+    "6ZTrmjer34": {
+        "data": {
+            "val": "commercial.community.prison.secureResidential",
+            "text": "Secure residential accommodation"
+        },
+        "type": 200
+    },
+    "6m7kgvL204": {
+        "data": {
+            "val": "flag.pp.priorApproval",
+            "text": "Prior approval"
+        },
+        "type": 200
+    },
+    "6s4OYxRuxF": {
+        "data": {
+            "text": "[Not currently in CSV]"
+        },
+        "type": 100
+    },
+    "77aMg0KaeL": {
+        "data": {
+            "val": "commercial.retail.market",
+            "text": "Market"
+        },
+        "type": 200
+    },
+    "7MvdNl3XE8": {
+        "data": {
+            "val": "commercial.education",
+            "text": "Education"
+        },
+        "type": 200,
+        "edges": [
+            "MvRUSyqezC"
+        ]
+    },
+    "87KjOi5c82": {
+        "data": {
+            "val": "residential.house",
+            "text": "House"
+        },
+        "type": 200,
+        "edges": [
+            "QgI87UIDEx"
+        ]
+    },
+    "9YqHTuXVjs": {
+        "data": {
+            "fn": "proposal.site",
+            "info": "<p>This outline identifies the location of the proposed changes on a map. This information is required for all planning applications. It is sometimes called a &apos;red line drawing&apos; or &apos;location plan&apos;.</p>",
+            "title": "Confirm your location plan",
+            "policyRef": "<p><a target=\"_blank\" rel=\"noopener noreferrer nofollow\" href=\"https://www.legislation.gov.uk/uksi/2015/595/article/7\">The Town and Country Planning (Development Management Procedure) (England) Order 2015</a>,</p><p><a target=\"_blank\" rel=\"noopener noreferrer nofollow\" href=\"https://www.gov.uk/government/collections/planning-practice-guidance\">Planning Practice Guidance (PPG)</a></p>",
+            "description": "<p>The red line shown below should include:</p><ul><li><p>the outline of your property boundary</p></li><li><p>any works outside the property boundary</p></li><li><p>areas that will be closed off or you&apos;ll need access to during the works</p></li></ul><p>If the red line already includes all these, select continue. If not, select More information for guidance on how to amend or redraw the outline.</p>",
+            "howMeasured": "<p>We have pre-populated the map with a red outline that includes the entire property using information from Land Registry.</p><p>In some cases, this outline might not include all the works or the areas that will be closed off. This might be because you&apos;re proposing works to a public highway (such as a dropped kerb), doing works that involve multiple properties, or works to a building that is part of a larger estate.</p><p>In these cases, you should amend the red outline by dragging the edges, or erase it by clicking the :wastebasket:-icon on the map and draw a new outline.</p><p></p><h1>How to draw and amend the outline</h1><ol><li><p>Move the cursor to the corner you want to start with and click or tap once.</p></li><li><p>Move the cursor to the next corner and click or tap.</p></li><li><p>Repeat until you have the shape you need.</p></li><li><p>Click or tap the last corner again to stop drawing.</p></li><li><p>To amend the outline, click or tap on a line and drag it into a new position.</p></li></ol><img src=\"https://api.editor.planx.uk/file/public/dni98ojg/Draw_Outline_2.gif\">",
+            "hideFileUpload": false,
+            "titleForUploading": "Upload a location plan",
+            "descriptionForUploading": "<p>Your location plan must:</p><ul><li><p>be based on an accurate, recognisable map</p></li><li><p>be drawn to a scale, labelled, and/or marked with a scale bar</p></li><li><p>show the site outline in red</p></li><li><p>include a<strong> </strong>north point</p></li></ul>"
+        },
+        "type": 10
+    },
+    "ABfyMaziTo": {
+        "data": {
+            "val": "commercial.transport.water.dock",
+            "text": "Harbour"
+        },
+        "type": 200
+    },
+    "Adop1mBxrE": {
+        "data": {
+            "fn": "property.type",
+            "val": "commercial.community",
+            "operation": "replace"
+        },
+        "type": 380
+    },
+    "AhFG90gq5e": {
+        "data": {
+            "val": "land.open.moor",
+            "text": "Heath or moorland"
+        },
+        "type": 200
+    },
+    "B2AMdGE1oz": {
+        "data": {
+            "fn": "property.type",
+            "val": "commercial.industrial",
+            "operation": "replace"
+        },
+        "type": 380
+    },
+    "C8JdGplv5s": {
+        "data": {
+            "img": "https://api.editor.planx.uk/file/public/btyxwr2j/housetypes_midterrace.png",
+            "val": "residential.house.terrace",
+            "text": "Terrace"
+        },
+        "type": 200
+    },
+    "CINNX8Ik3s": {
+        "data": {
+            "val": "commercial.leisure.other",
+            "text": "Another leisure use"
+        },
+        "type": 200,
+        "edges": [
+            "tM7xu5U0Yr"
+        ]
+    },
+    "DvxdLfWY7y": {
+        "data": {
+            "fn": "property.type",
+            "val": "commercial.medical",
+            "operation": "replace"
+        },
+        "type": 380
+    },
+    "EneWmbOdWx": {
+        "data": {
+            "val": "industrial.mining",
+            "text": "Industrial mining"
+        },
+        "type": 200
+    },
+    "F10jdwjqbj": {
+        "data": {
+            "val": "commercial.transport",
+            "text": "Transport"
+        },
+        "type": 200,
+        "edges": [
+            "ua6mDtxpWH"
+        ]
+    },
+    "F7lubrvq95": {
+        "data": {
+            "val": "object.religious.building.temple",
+            "text": "Temple"
+        },
+        "type": 200
+    },
+    "FJnLFg4GBi": {
+        "data": {
+            "val": "commercial.transport.rail.terminal",
+            "text": "Train station"
+        },
+        "type": 200
+    },
+    "Ff1vOjzAVD": {
+        "data": {
+            "val": "commercial.retail.showroom",
+            "text": "Showroom"
+        },
+        "type": 200
+    },
+    "GB3a9Uxm42": {
+        "data": {
+            "val": "commercial.leisure.museum",
+            "text": "Museum"
+        },
+        "type": 200
+    },
+    "GF2Ubxttu3": {
+        "data": {
+            "val": "object.religious.building",
+            "text": "Another type of religious building"
+        },
+        "type": 200
+    },
+    "GIfqiZqsPC": {
+        "data": {
+            "val": "commercial.community.other",
+            "text": "Another institutional building"
+        },
+        "type": 200,
+        "edges": [
+            "Adop1mBxrE"
+        ]
+    },
+    "GJZ7xULXqK": {
+        "data": {
+            "val": "commercial.industrial.extraction",
+            "text": "Extraction"
+        },
+        "type": 200
+    },
+    "GhtCWiIfnx": {
+        "data": {
+            "val": "military",
+            "text": "Military"
+        },
+        "type": 200
+    },
+    "GspcOr57zL": {
+        "data": {
+            "val": "commercial.office.workspace",
+            "text": "Office"
+        },
+        "type": 200
+    },
+    "HSVuNf2tZG": {
+        "data": {
+            "val": "flag.pp.notice",
+            "text": "Notice"
+        },
+        "type": 200
+    },
+    "HaOcUgqqqP": {
+        "data": {
+            "val": "object.religious.building.synagogue",
+            "text": "Synagogue"
+        },
+        "type": 200
+    },
+    "Hx11x57Zy8": {
+        "data": {
+            "val": "object.religious.building.church",
+            "text": "Church"
+        },
+        "type": 200
+    },
+    "I03hRPF3ck": {
+        "data": {
+            "fn": "property.type",
+            "text": "What type of property is it?",
+            "notes": "Added definition of HMO. \nHA",
+            "howMeasured": "<p><strong>Flats</strong> includes maisonettes (a flat with more than one storey that is within a shared building).</p><p><strong>A house in multiple occupation (HMO)</strong> has:</p><ul><li><p>at least 3 tenants living there, forming more than 1 household</p></li><li><p>a shared toilet, bathroom or kitchen facilities between tenants</p></li></ul>"
+        },
+        "type": 100,
+        "edges": [
+            "87KjOi5c82",
+            "2Z4Ah7QPvE",
+            "M9bF7tV5Mx",
+            "hrVQ3UrdMQ"
+        ]
+    },
+    "J4IXSAlPTw": {
+        "data": {
+            "val": "commercial.industrial.other",
+            "text": "Another industrial use"
+        },
+        "type": 200,
+        "edges": [
+            "B2AMdGE1oz"
+        ]
+    },
+    "JewE77gtFE": {
+        "data": {
+            "val": "commercial.office.broadcasting",
+            "text": "Broadcasting studio"
+        },
+        "type": 200
+    },
+    "JkyukIyZ5r": {
+        "data": {
+            "text": "What about garden of X property? For 'building X in the land around a building'?"
+        },
+        "type": 100
+    },
+    "KOBzBAzzNG": {
+        "data": {
+            "val": "commercial.community.prison",
+            "text": "Prison"
+        },
+        "type": 200
+    },
+    "KelsJUMvcF": {
+        "data": {
+            "val": "commercial.transport.air",
+            "text": "Airport or airfield"
+        },
+        "type": 200
+    },
+    "KhqvCr57zL": {
+        "data": {
+            "fn": "property.type",
+            "text": "What type of commercial property is it?"
+        },
+        "type": 100,
+        "edges": [
+            "GspcOr57zL",
+            "wenuhnHnzR",
+            "JewE77gtFE",
+            "kGyQVr57zL"
+        ]
+    },
+    "LT6T7RR5O3": {
+        "data": {
+            "val": "flag.pp.permittedDevelopment",
+            "text": "Permitted development"
+        },
+        "type": 200
+    },
+    "LU5xin8PHs": {
+        "data": {
+            "fn": "property.type",
+            "text": "Which of these best describes the use of the property?"
+        },
+        "type": 100,
+        "edges": [
+            "TCYyJ2dnVQ",
+            "xuFhs3Hqr9",
+            "jImvxS3FNw",
+            "7MvdNl3XE8",
+            "xtrFvDHgOI",
+            "1nHpe53Ytm",
+            "WVQ0zdfUXz",
+            "F10jdwjqbj",
+            "qEPAzJoB8Y",
+            "N1752okA56",
+            "3TJYlfAUz6",
+            "vXLzCpHPRs"
+        ]
+    },
+    "LZ5owtXc8R": {
+        "data": {
+            "val": "object.religious.building.minster",
+            "text": "Minster"
+        },
+        "type": 200
+    },
+    "LczMuHy8w6": {
+        "data": {
+            "val": "flag.pp.notDevelopment",
+            "text": "Not development"
+        },
+        "type": 200
+    },
+    "M25kTJaupX": {
+        "data": {
+            "fn": "proposal.site.area.half",
+            "title": "Half the site boundary",
+            "formula": "proposal.site.area/2",
+            "defaults": {
+                "proposal.site.area": "0"
+            },
+            "formatOutputForAutomations": false
+        },
+        "type": 700
+    },
+    "M7Y93oTya3": {
+        "data": {
+            "fn": "property.type",
+            "text": "What type of leisure property is it?"
+        },
+        "type": 100,
+        "edges": [
+            "vwLsi2H7oK",
+            "VCa3N3ujER",
+            "GB3a9Uxm42",
+            "OWqVZ4U2Wu",
+            "nNw3oBYWf9",
+            "NtMJjAqat0",
+            "3uLzlsc0DS",
+            "r2Y8ydTsCn",
+            "PcFmfgw6vr",
+            "CINNX8Ik3s"
+        ]
+    },
+    "M9bF7tV5Mx": {
+        "data": {
+            "val": "residential.HMO",
+            "text": "A house in multiple occupation (HMO)"
+        },
+        "type": 200
+    },
+    "MQzrk4KPRO": {
+        "data": {
+            "fn": "flag",
+            "category": "Works to listed buildings"
+        },
+        "type": 500,
+        "edges": [
+            "5TB6qVisoq",
+            "fx0w4IdBU3",
+            "zHeTwH6CaY",
+            "ik25RDDUyG",
+            "wgJ5dK7N7u"
+        ]
+    },
+    "MvRUSyqezC": {
+        "data": {
+            "fn": "property.type",
+            "text": "What type of educational building is it?",
+            "notes": "SEND: Education for children and young people aged 3-19 with complex physical disabilities and health needs"
+        },
+        "type": 100,
+        "edges": [
+            "orpJWHhk3f",
+            "vUwbhBmVob",
+            "q7bavn1mz3",
+            "Vv1i0rOiKk",
+            "twOdAbGD0c",
+            "ZOtL3MUARu",
+            "5yGblc1zi8"
+        ]
+    },
+    "N1752okA56": {
+        "data": {
+            "val": "land",
+            "text": "Land"
+        },
+        "type": 200,
+        "edges": [
+            "6s4OYxRuxF",
+            "v9MhybjSFf"
+        ]
+    },
+    "N8T7u2fedh": {
+        "data": {
+            "title": "Find the property",
+            "newAddressTitle": "Click or tap at where the property is on the map and name it below",
+            "allowNewAddresses": false,
+            "newAddressDescription": "You will need to select a location and provide a name to continue",
+            "newAddressDescriptionLabel": "Name the site"
+        },
+        "type": 9
+    },
+    "NRxZatvY3G": {
+        "data": {
+            "val": "commercial.agriculture.land",
+            "text": "Agricultural"
+        },
+        "type": 200
+    },
+    "NWT3CsFSCz": {
+        "data": {
+            "val": "commercial.storage",
+            "text": "Storage"
+        },
+        "type": 200
+    },
+    "NtMJjAqat0": {
+        "data": {
+            "val": "commercial.leisure.entertainment.cinema",
+            "text": "Cinema"
+        },
+        "type": 200
+    },
+    "OWqVZ4U2Wu": {
+        "data": {
+            "val": "commercial.leisure.sport",
+            "text": "Indoor or outdoor sport"
+        },
+        "type": 200
+    },
+    "PNoPwbkS2L": {
+        "data": {
+            "val": "object.religious.building.mosque",
+            "text": "Mosque"
+        },
+        "type": 200
+    },
+    "PXI9SWUFSM": {
+        "data": {
+            "tags": [],
+            "title": "About the property",
+            "description": "<p>This is the information we currently have about the property.</p><p>The blue line shows the <strong>outline</strong> of the property (known as the title boundary). If this looks incorrect, go back a step and <strong>check you have selected the correct address</strong>.</p><p>We use this outline to create the site boundary where the project will take place. If your project covers a different area, you can change or redraw the site boundary on the next page.</p>",
+            "showPropertyTypeOverride": true
+        },
+        "type": 12
+    },
+    "PcFmfgw6vr": {
+        "data": {
+            "val": "commercial.leisure.park.zoo",
+            "text": "Zoo or theme park"
+        },
+        "type": 200
+    },
+    "QF9PQ7c53U": {
+        "data": {
+            "text": "No flag result"
+        },
+        "type": 200
+    },
+    "QQYPyFijad": {
+        "data": {
+            "img": "https://api.editor.planx.uk/file/public/2jpkk6ei/housetypes_semiDetached.png",
+            "val": "residential.house.semiDetached",
+            "text": "Semi-detached"
+        },
+        "type": 200
+    },
+    "QgI87UIDEx": {
+        "data": {
+            "fn": "property.type",
+            "text": "What type of house is it?",
+            "howMeasured": "<p><strong>A detached house</strong> is not joined to another property.</p><p><strong>A semi-detached house </strong>is joined to 1 other property which, in turn, is not attached to any other properties. So together, the 2 properties form a pair.</p><p><strong>A terrace</strong> is a building that forms part of a row of 3 or more adjoining properties. This includes buildings at the end of the row (an <strong>end terrace</strong>).</p>"
+        },
+        "type": 100,
+        "edges": [
+            "aJzng1LAVi",
+            "QQYPyFijad",
+            "C8JdGplv5s",
+            "jY5LKeMShO"
+        ]
+    },
+    "S50pYmgKlM": {
+        "data": {
+            "val": "flood",
+            "text": "Flood zone",
+            "flags": [
+                "flag.pp.notice",
+                "flag.wtt.notRequired"
+            ]
+        },
+        "type": 200,
+        "edges": [
+            "wvRHLsZyyk"
+        ]
+    },
+    "SKHnXGOeXP": {
+        "data": {
+            "val": "commercial.animals",
+            "text": "Vet,  kennels, cattery or stables"
+        },
+        "type": 200
+    },
+    "TCYyJ2dnVQ": {
+        "data": {
+            "val": "commercial.retail",
+            "text": "Retail and services"
+        },
+        "type": 200,
+        "edges": [
+            "ZA71kgL6Q2"
+        ]
+    },
+    "TEojcnNYlP": {
+        "data": {
+            "val": "other.leisure",
+            "text": "Sport or other leisure"
+        },
+        "type": 200
+    },
+    "U771mX7pcX": {
+        "data": {
+            "val": "residential.carParkingSpace",
+            "text": "Car parking for a residential property"
+        },
+        "type": 200
+    },
+    "URAW8XuIIp": {
+        "data": {
+            "val": "commercial.retail.restaurant",
+            "text": "Restaurant"
+        },
+        "type": 200
+    },
+    "UTrsADvRG0": {
+        "data": {
+            "val": "commercial.medical.other",
+            "text": "Another health or care use"
+        },
+        "type": 200,
+        "edges": [
+            "DvxdLfWY7y"
+        ]
+    },
+    "UW5C3zLAVR": {
+        "data": {
+            "fn": "property.type",
+            "val": "commercial.industrial",
+            "operation": "replace"
+        },
+        "type": 380
+    },
+    "VCa3N3ujER": {
+        "data": {
+            "val": "commercial.leisure.holiday",
+            "text": "Campsite"
+        },
+        "type": 200
+    },
+    "VQeVVLKA7Q": {
+        "data": {
+            "val": "land.unused",
+            "text": "Unused land"
+        },
+        "type": 200
+    },
+    "Vv1i0rOiKk": {
+        "data": {
+            "val": "commercial.education.college",
+            "text": "College"
+        },
+        "type": 200
+    },
+    "W5tCOXfKqp": {
+        "data": {
+            "val": "flag.pp.missingInfo",
+            "text": "Missing information"
+        },
+        "type": 200
+    },
+    "W7N5RqjC7L": {
+        "data": {
+            "val": "commercial.community.court",
+            "text": "Law court"
+        },
+        "type": 200
+    },
+    "WVQ0zdfUXz": {
+        "data": {
+            "val": "commercial.medical",
+            "text": "Health and care"
+        },
+        "type": 200,
+        "edges": [
+            "mRevTOrtYj"
+        ]
+    },
+    "WViyJ3YQxi": {
+        "data": {
+            "val": "other.historic",
+            "text": "Historic site"
+        },
+        "type": 200
+    },
+    "WlBAHtMtuv": {
+        "data": {
+            "fn": "property.type",
+            "val": "commercial.transport",
+            "operation": "replace"
+        },
+        "type": 380
+    },
+    "XDlfXlSFJY": {
+        "data": {
+            "fn": "property.constraints.planning",
+            "title": "Planning constraints",
+            "dataValues": [
+                "articleFour",
+                "articleFour.caz",
+                "brownfieldSite",
+                "designated.AONB",
+                "designated.conservationArea",
+                "greenBelt",
+                "designated.nationalPark",
+                "designated.nationalPark.broads",
+                "designated.WHS",
+                "flood",
+                "listed",
+                "monument",
+                "nature.ASNW",
+                "nature.ramsarSite",
+                "nature.SAC",
+                "nature.SPA",
+                "nature.SSSI",
+                "registeredPark",
+                "tpo",
+                "road.classified"
+            ],
+            "disclaimer": "<p><strong>This page does not include information about historic planning conditions that may apply to this property.</strong></p>",
+            "description": "Planning constraints might limit how you can develop or use the property"
+        },
+        "type": 11
+    },
+    "XTgtfwSuLQ": {
+        "data": {
+            "fn": "property.type",
+            "text": "What type of institutional building is it?"
+        },
+        "type": 100,
+        "edges": [
+            "ZcTXKBc4vS",
+            "4xoUWkORDG",
+            "W7N5RqjC7L",
+            "KOBzBAzzNG",
+            "6ZTrmjer34",
+            "oAh53Sdhlf",
+            "GIfqiZqsPC"
+        ]
+    },
+    "XrXi3rlRSZ": {
+        "data": {
+            "val": "object.religious.building.chapel",
+            "text": "Chapel"
+        },
+        "type": 200
+    },
+    "Xz0qrhi8H7": {
+        "data": {
+            "fn": "property.constraints.planning",
+            "tags": [],
+            "text": "Which article 4s apply?",
+            "allRequired": false,
+            "neverAutoAnswer": false
+        },
+        "type": 105,
+        "edges": [
+            "2FoekDHPbA",
+            "3zhtpyYEE1",
+            "m8JEFawEKD"
+        ]
+    },
+    "Y2kRmeO81E": {
+        "data": {
+            "val": "land.allotment",
+            "text": "Allotment"
+        },
+        "type": 200
+    },
+    "YSoz99VKge": {
+        "data": {
+            "val": "object.religious.building.kingdomHall",
+            "text": "Kingdom Hall"
+        },
+        "type": 200
+    },
+    "YjzESqJ4qq": {
+        "data": {
+            "val": "commercial.retail.post",
+            "text": "Post office"
+        },
+        "type": 200
+    },
+    "Z9dOoU0dD1": {
+        "data": {
+            "fn": "flag",
+            "category": "Planning permission"
+        },
+        "type": 500,
+        "edges": [
+            "xkTXHHPGDf",
+            "W5tCOXfKqp",
+            "qrZ7hJFcwj",
+            "6m7kgvL204",
+            "HSVuNf2tZG",
+            "LT6T7RR5O3",
+            "LczMuHy8w6",
+            "QF9PQ7c53U"
+        ]
+    },
+    "ZA71kgL6Q2": {
+        "data": {
+            "fn": "property.type",
+            "text": "What type of retail unit is it?"
+        },
+        "type": 100,
+        "edges": [
+            "m6PbWCB1we",
+            "mGlGlqZNMY",
+            "xCcQJDKF1l",
+            "URAW8XuIIp",
+            "h4XLYS8afw",
+            "YjzESqJ4qq",
+            "3s74llQcam",
+            "77aMg0KaeL",
+            "Ff1vOjzAVD",
+            "3Pp2uvwRfG",
+            "6IQpHgCEso",
+            "4n7h4JzAJR"
+        ]
+    },
+    "ZOtL3MUARu": {
+        "data": {
+            "val": "commercial.education.specialNeeds",
+            "text": "Special educational needs"
+        },
+        "type": 200
+    },
+    "ZcTXKBc4vS": {
+        "data": {
+            "val": "commercial.community.wc",
+            "text": "Public WC"
+        },
+        "type": 200
+    },
+    "a0OE4T9hhz": {
+        "data": {
+            "val": "other.unsupported.travellingPersons",
+            "text": "Travellers site"
+        },
+        "type": 200
+    },
+    "aJzng1LAVi": {
+        "data": {
+            "img": "https://api.editor.planx.uk/file/public/pk8f4g4h/housetypes_detached.png",
+            "val": "residential.house.detached",
+            "text": "Detached"
+        },
+        "type": 200
+    },
+    "b6Bd8rgmZ8": {
+        "data": {
+            "val": "land.development",
+            "text": "Development site"
+        },
+        "type": 200
+    },
+    "bKyYzKGOAe": {
+        "data": {
+            "val": "other.agriculture",
+            "text": "Agricultural support (pen, pit, ladder etc.)"
+        },
+        "type": 200
+    },
+    "bsPJXND9ig": {
+        "data": {
+            "val": "listed.gradeTwoStar",
+            "text": "Grade II*"
+        },
+        "type": 200
+    },
+    "cLkrqEThSB": {
+        "data": {
+            "val": "alter.decks",
+            "text": "Add a deck"
+        },
+        "type": 200
+    },
+    "cR39C6xDzK": {
+        "data": {
+            "val": "commercial.transport.freight",
+            "text": "Freight handling facility (such as a shipping container port)"
+        },
+        "type": 200
+    },
+    "duTwH18KKr": {
+        "data": {
+            "val": "land.other",
+            "text": "Another land use"
+        },
+        "type": 200,
+        "edges": [
+            "3lblfduLSS"
+        ]
+    },
+    "eR4Uk4wds5": {
+        "data": {
+            "val": "object.religious.building.cathedral",
+            "text": "Cathedral"
+        },
+        "type": 200
+    },
+    "fFaIGwurhW": {
+        "data": {
+            "val": "land.forest",
+            "text": "Forestry"
+        },
+        "type": 200
+    },
+    "fHWLxi5ejZ": {
+        "data": {
+            "val": "commercial.transport.road.parking",
+            "text": "Car park"
+        },
+        "type": 200
+    },
+    "fR27RXqLNn": {
+        "data": {
+            "val": "listed.gradeTwo",
+            "text": "Grade II"
+        },
+        "type": 200
+    },
+    "fx0w4IdBU3": {
+        "data": {
+            "val": "flag.lbc.consentNeeded",
+            "text": "Consent needed"
+        },
+        "type": 200
+    },
+    "gL3852rbg7": {
+        "data": {
+            "val": "commercial.medical.healthCentre",
+            "text": "Health centre"
+        },
+        "type": 200
+    },
+    "h4XLYS8afw": {
+        "data": {
+            "val": "commercial.retail.takeaway",
+            "text": "Food takeaway"
+        },
+        "type": 200
+    },
+    "hNvEwECRda": {
+        "data": {
+            "fn": "property.type.userProvided",
+            "type": "short",
+            "title": "What type of property is it?"
+        },
+        "type": 110
+    },
+    "hrVQ3UrdMQ": {
+        "data": {
+            "text": "Something else"
+        },
+        "type": 200,
+        "edges": [
+            "LU5xin8PHs"
+        ]
+    },
+    "ik25RDDUyG": {
+        "data": {
+            "val": "flag.lbc.notRequired",
+            "text": "Not required"
+        },
+        "type": 200
+    },
+    "jImvxS3FNw": {
+        "data": {
+            "val": "commercial.office",
+            "text": "Commercial"
+        },
+        "type": 200,
+        "edges": [
+            "KhqvCr57zL"
+        ]
+    },
+    "jY5LKeMShO": {
+        "data": {
+            "img": "https://api.editor.planx.uk/file/public/u0lwhiv2/housetypes_endterrace.png",
+            "val": "residential.house.terrace",
+            "text": "End terrace"
+        },
+        "type": 200
+    },
+    "jtVZ3Xa3DE": {
+        "data": {
+            "fn": "property.constraints.planning",
+            "text": "Which grade listed buildings?",
+            "allRequired": false,
+            "neverAutoAnswer": false
+        },
+        "type": 105,
+        "edges": [
+            "rKeLQit5lP",
+            "fR27RXqLNn",
+            "bsPJXND9ig"
+        ]
+    },
+    "kGyQVr57zL": {
+        "data": {
+            "val": "commercial.office.other",
+            "text": "Something else"
+        },
+        "type": 200,
+        "edges": [
+            "mbOwaGPJuU"
+        ]
+    },
+    "m6PbWCB1we": {
+        "data": {
+            "val": "commercial.retail.shop",
+            "text": "Shop"
+        },
+        "type": 200
+    },
+    "m8JEFawEKD": {
+        "data": {
+            "val": "articleFour",
+            "text": "Something else"
+        },
+        "type": 200
+    },
+    "mGlGlqZNMY": {
+        "data": {
+            "val": "commercial.retail.licensedPremises",
+            "text": "Off-licence"
+        },
+        "type": 200
+    },
+    "mRViARNa4U": {
+        "data": {
+            "val": "commercial.medical.careHome",
+            "text": "Care home"
+        },
+        "type": 200
+    },
+    "mRevTOrtYj": {
+        "data": {
+            "fn": "property.type",
+            "text": "What type of medical or care building is it?"
+        },
+        "type": 100,
+        "edges": [
+            "tAEd8K9ih8",
+            "2MlqAY7JKX",
+            "gL3852rbg7",
+            "mRViARNa4U",
+            "y1vXEBLI3y",
+            "UTrsADvRG0"
+        ]
+    },
+    "mbOwaGPJuU": {
+        "data": {
+            "fn": "property.type",
+            "val": "commercial.office",
+            "operation": "replace"
+        },
+        "type": 380
+    },
+    "nAQtDxo6c4": {
+        "data": {
+            "val": "commercial.industrial.manufacturing",
+            "text": "Manufacturing"
+        },
+        "type": 200
+    },
+    "nNw3oBYWf9": {
+        "data": {
+            "val": "commercial.leisure.entertainment",
+            "text": "Entertainment"
+        },
+        "type": 200
+    },
+    "nxoyVfZGlZ": {
+        "data": {
+            "text": "Something else"
+        },
+        "type": 200
+    },
+    "oAh53Sdhlf": {
+        "data": {
+            "val": "commercial.community.cemetery",
+            "text": "Cemetery or crematorium"
+        },
+        "type": 200
+    },
+    "oIqbT6ofX4": {
+        "data": {
+            "val": "object.religious.building.gurdwara",
+            "text": "Gurdwara"
+        },
+        "type": 200
+    },
+    "ok2w6dmuEw": {
+        "data": {
+            "val": "object.religious.building.lychGate",
+            "text": "Lych Gate"
+        },
+        "type": 200
+    },
+    "orpJWHhk3f": {
+        "data": {
+            "val": "commercial.education.nursery",
+            "text": "Nursery"
+        },
+        "type": 200
+    },
+    "pk3SFkfK0r": {
+        "data": {
+            "val": "object.religious.building.stupa",
+            "text": "Stupa"
+        },
+        "type": 200
+    },
+    "q7bavn1mz3": {
+        "data": {
+            "val": "commercial.education.school.secondary",
+            "text": "Secondary school"
+        },
+        "type": 200
+    },
+    "qEPAzJoB8Y": {
+        "data": {
+            "val": "commercial.agriculture",
+            "text": "Agriculture"
+        },
+        "type": 200
+    },
+    "qrZ7hJFcwj": {
+        "data": {
+            "val": "flag.pp.permissionNeeded",
+            "text": "Permission needed"
+        },
+        "type": 200
+    },
+    "r2Y8ydTsCn": {
+        "data": {
+            "val": "commercial.leisure.entertainment.exhibition",
+            "text": "Exhibition centre"
+        },
+        "type": 200
+    },
+    "r9hNgcu8xe": {
+        "data": {
+            "val": "flood.zoneOne",
+            "text": "Zone 1 (Low)"
+        },
+        "type": 200
+    },
+    "rKeLQit5lP": {
+        "data": {
+            "val": "listed.gradeOne",
+            "text": "Grade I"
+        },
+        "type": 200
+    },
+    "rQ3yeKMo3r": {
+        "data": {
+            "val": "internal.loft",
+            "text": "Add a loft"
+        },
+        "type": 200
+    },
+    "sYZiGbSwXS": {
+        "data": {
+            "fn": "property.type",
+            "text": "What type of property is it?"
+        },
+        "type": 100,
+        "edges": [
+            "U771mX7pcX",
+            "GhtCWiIfnx",
+            "WViyJ3YQxi",
+            "SKHnXGOeXP",
+            "a0OE4T9hhz",
+            "bKyYzKGOAe",
+            "TEojcnNYlP",
+            "5lzcg8luJT",
+            "3FiKmXz0Ct"
+        ]
+    },
+    "tAEd8K9ih8": {
+        "data": {
+            "val": "commercial.medical.GP",
+            "text": "Doctors surgery / clinic (GP)"
+        },
+        "type": 200
+    },
+    "tM7xu5U0Yr": {
+        "data": {
+            "fn": "property.type",
+            "val": "commercial.leisure",
+            "operation": "replace"
+        },
+        "type": 380
+    },
+    "tUsd2VX0CE": {
+        "data": {
+            "val": "articleFour",
+            "text": "Article 4",
+            "flags": [
+                "flag.pp.permissionNeeded",
+                "flag.planningPolicy.edgeCase"
+            ]
+        },
+        "type": 200,
+        "edges": [
+            "Xz0qrhi8H7"
+        ]
+    },
+    "twOdAbGD0c": {
+        "data": {
+            "val": "commercial.education.university",
+            "text": "University"
+        },
+        "type": 200
+    },
+    "uIciTYALsx": {
+        "data": {
+            "val": "internal.mezzanine",
+            "text": "Add a mezzanine floor"
+        },
+        "type": 200
+    },
+    "ua6mDtxpWH": {
+        "data": {
+            "fn": "property.type",
+            "text": "What type of transport property is it?"
+        },
+        "type": 100,
+        "edges": [
+            "FJnLFg4GBi",
+            "6TxMlBZqzW",
+            "KelsJUMvcF",
+            "fHWLxi5ejZ",
+            "cR39C6xDzK",
+            "ABfyMaziTo",
+            "yScStbKFow"
+        ]
+    },
+    "v9MhybjSFf": {
+        "data": {
+            "fn": "property.type",
+            "text": "What type of land is it?"
+        },
+        "type": 100,
+        "edges": [
+            "NRxZatvY3G",
+            "fFaIGwurhW",
+            "xpaP7v9BUG",
+            "Y2kRmeO81E",
+            "yRuZtDETJk",
+            "AhFG90gq5e",
+            "02aNXeNi17",
+            "vfA4cZoPKS",
+            "b6Bd8rgmZ8",
+            "VQeVVLKA7Q",
+            "duTwH18KKr"
+        ]
+    },
+    "vEr4UyFu4u": {
+        "data": {
+            "fn": "proposal.projectType",
+            "text": "What type of project are you doing?",
+            "neverAutoAnswer": false
+        },
+        "type": 100,
+        "edges": [
+            "vuhp0uk862",
+            "cLkrqEThSB",
+            "uIciTYALsx",
+            "rQ3yeKMo3r",
+            "EneWmbOdWx",
+            "nxoyVfZGlZ"
+        ]
+    },
+    "vUwbhBmVob": {
+        "data": {
+            "val": "commercial.education.school",
+            "text": "School"
+        },
+        "type": 200
+    },
+    "vXLzCpHPRs": {
+        "data": {
+            "text": "Other"
+        },
+        "type": 200,
+        "edges": [
+            "sYZiGbSwXS"
+        ]
+    },
+    "vfA4cZoPKS": {
+        "data": {
+            "val": "land.water",
+            "text": "Water"
+        },
+        "type": 200
+    },
+    "vuhp0uk862": {
+        "data": {
+            "val": "changeOfUse",
+            "text": "Change of use"
+        },
+        "type": 200
+    },
+    "vwLsi2H7oK": {
+        "data": {
+            "val": "commercial.leisure.library",
+            "text": "Library"
+        },
+        "type": 200
+    },
+    "wenuhnHnzR": {
+        "data": {
+            "val": "commercial.office.workspace.film",
+            "text": "Film studio"
+        },
+        "type": 200
+    },
+    "wgJ5dK7N7u": {
+        "data": {
+            "text": "No flag result"
+        },
+        "type": 200
+    },
+    "wkNZj4EJuR": {
+        "data": {
+            "val": "object.religious.building.abbey",
+            "text": "Abbey"
+        },
+        "type": 200
+    },
+    "wvRHLsZyyk": {
+        "data": {
+            "fn": "property.constraints.planning",
+            "text": "Which risk level?",
+            "allRequired": false,
+            "neverAutoAnswer": false
+        },
+        "type": 105,
+        "edges": [
+            "r9hNgcu8xe",
+            "0FIHMM1vcO",
+            "x4Zma010vS"
+        ]
+    },
+    "x4Zma010vS": {
+        "data": {
+            "val": "flood.zoneThree",
+            "text": "Zone 3 (High)"
+        },
+        "type": 200
+    },
+    "xCcQJDKF1l": {
+        "data": {
+            "val": "commercial.retail.services",
+            "text": "Bank or financial service"
+        },
+        "type": 200
+    },
+    "xHPFIDDV1V": {
+        "data": {
+            "val": "commercial.storage.distribution",
+            "text": "Distribution"
+        },
+        "type": 200
+    },
+    "xkTXHHPGDf": {
+        "data": {
+            "val": "flag.pp.immune",
+            "text": "Immune"
+        },
+        "type": 200
+    },
+    "xpaP7v9BUG": {
+        "data": {
+            "val": "land.park",
+            "text": "Park"
+        },
+        "type": 200
+    },
+    "xtrFvDHgOI": {
+        "data": {
+            "val": "commercial.industrial",
+            "text": "Industrial"
+        },
+        "type": 200,
+        "edges": [
+            "1ElP19Mpqq"
+        ]
+    },
+    "xuFhs3Hqr9": {
+        "data": {
+            "val": "commercial.leisure",
+            "text": "Leisure and sport"
+        },
+        "type": 200,
+        "edges": [
+            "M7Y93oTya3"
+        ]
+    },
+    "y1vXEBLI3y": {
+        "data": {
+            "val": "commercial.medical.lab",
+            "text": "Medical, testing or research laboratory"
+        },
+        "type": 200
+    },
+    "yRuZtDETJk": {
+        "data": {
+            "val": "land.open",
+            "text": "Open space"
+        },
+        "type": 200
+    },
+    "yScStbKFow": {
+        "data": {
+            "val": "commercial.transport.other",
+            "text": "Another transport use"
+        },
+        "type": 200,
+        "edges": [
+            "WlBAHtMtuv"
+        ]
+    },
+    "zHeTwH6CaY": {
+        "data": {
+            "val": "flag.lbc.deMinimis",
+            "text": "De minimis"
+        },
+        "type": 200
+    },
+    "6689164d-2a5e-422f-8d6a-d3ea11a2fbb9": {
+        "data": {
+            "text": "opensystemslab/property-types",
+            "summary": null,
+            "publishedAt": "2024-08-14T16:47:14.79483+00:00",
+            "publishedBy": 84,
+            "publishedFlowId": 3961
+        },
+        "type": 300,
+        "edges": [
+            "6FL5k5zovo",
+            "JkyukIyZ5r",
+            "I03hRPF3ck"
+        ]
+    }
+};
+
+module.exports = { expectedFlow };

--- a/jan2025_revisedSessions/tests/mocks/expectedSession.js
+++ b/jan2025_revisedSessions/tests/mocks/expectedSession.js
@@ -1,0 +1,2704 @@
+const expectedSession = {
+  id: "9935e59d-904c-401f-bd1e-524ca91a1abc",
+  passport: {
+    "data": {
+      "_address": {
+        "uprn": "200003453172",
+        "usrn": "22500531",
+        "blpu_code": "2",
+        "latitude": 51.4842536,
+        "longitude": -0.0764166,
+        "organisation": null,
+        "sao": "FLAT 6",
+        "pao": "103",
+        "street": "COBOURG ROAD",
+        "town": "LONDON",
+        "postcode": "SE5 0HU",
+        "ward": "E05011109",
+        "x": 533660.36,
+        "y": 177898.47,
+        "planx_description": "Residential - Flat",
+        "planx_value": "residential.dwelling.flat", // this doesn't need updated as long as property.type is correct
+        "single_line_address": "FLAT 6, 103, COBOURG ROAD, LONDON, SOUTHWARK, SE5 0HU",
+        "title": "FLAT 6, 103, COBOURG ROAD, LONDON",
+        "source": "os"
+      },
+      "property.type": [
+        "residential.flat"
+      ],
+      "property.localAuthorityDistrict": [
+        "Southwark"
+      ],
+      "property.region": [
+        "London"
+      ],
+      "property.boundary": {
+        "geometry": {
+          "type": "MultiPolygon",
+          "coordinates": [
+            [
+              [
+                [
+                  -0.076691,
+                  51.484197
+                ],
+                [
+                  -0.075933,
+                  51.484124
+                ],
+                [
+                  -0.075856,
+                  51.484369
+                ],
+                [
+                  -0.075889,
+                  51.484372
+                ],
+                [
+                  -0.0759,
+                  51.484324
+                ],
+                [
+                  -0.076391,
+                  51.484369
+                ],
+                [
+                  -0.076388,
+                  51.484383
+                ],
+                [
+                  -0.076644,
+                  51.484409
+                ],
+                [
+                  -0.076691,
+                  51.484197
+                ]
+              ]
+            ]
+          ]
+        },
+        "type": "Feature",
+        "properties": {
+          "entry-date": "2024-05-06",
+          "start-date": "2011-08-25",
+          "end-date": "",
+          "entity": 12000601059,
+          "name": "",
+          "dataset": "title-boundary",
+          "typology": "geography",
+          "reference": "52725257",
+          "prefix": "title-boundary",
+          "organisation-entity": "13"
+        }
+      },
+      "property.boundary.area": 1232.22,
+      "property.boundary.area.hectares": 0.123222,
+      "findProperty.action": "Selected an existing address",
+      "propertyInformation.action": "Accepted the property type",
+      "proposal.site": {
+        "geometry": {
+          "type": "MultiPolygon",
+          "coordinates": [
+            [
+              [
+                [
+                  -0.076691,
+                  51.484197
+                ],
+                [
+                  -0.075933,
+                  51.484124
+                ],
+                [
+                  -0.075856,
+                  51.484369
+                ],
+                [
+                  -0.075889,
+                  51.484372
+                ],
+                [
+                  -0.0759,
+                  51.484324
+                ],
+                [
+                  -0.076391,
+                  51.484369
+                ],
+                [
+                  -0.076388,
+                  51.484383
+                ],
+                [
+                  -0.076644,
+                  51.484409
+                ],
+                [
+                  -0.076691,
+                  51.484197
+                ]
+              ]
+            ]
+          ]
+        },
+        "type": "Feature",
+        "properties": {
+          "entry-date": "2024-05-06",
+          "start-date": "2011-08-25",
+          "end-date": "",
+          "entity": 12000601059,
+          "name": "",
+          "dataset": "title-boundary",
+          "typology": "geography",
+          "reference": "52725257",
+          "prefix": "title-boundary",
+          "organisation-entity": "13"
+        }
+      },
+      "proposal.site.buffered": {
+        "type": "Feature",
+        "properties": {
+          "entry-date": "2024-05-06",
+          "start-date": "2011-08-25",
+          "end-date": "",
+          "entity": 12000601059,
+          "name": "",
+          "dataset": "title-boundary",
+          "typology": "geography",
+          "reference": "52725257",
+          "prefix": "title-boundary",
+          "organisation-entity": "13"
+        },
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                -0.07840771069514788,
+                51.48434457711614
+              ],
+              [
+                -0.07842115842704286,
+                51.48413536783419
+              ],
+              [
+                -0.07836948082188315,
+                51.48392847894068
+              ],
+              [
+                -0.07825462393878962,
+                51.48373169794115
+              ],
+              [
+                -0.07808091182941154,
+                51.483552431772814
+              ],
+              [
+                -0.07785488367358213,
+                51.48339742802321
+              ],
+              [
+                -0.07758504757401118,
+                51.48327252097795
+              ],
+              [
+                -0.07728156028667897,
+                51.483182412050674
+              ],
+              [
+                -0.07695584494421384,
+                51.48313049285461
+              ],
+              [
+                -0.07619786224769512,
+                51.48305749456187
+              ],
+              [
+                -0.07586728536909972,
+                51.4830455917509
+              ],
+              [
+                -0.07553910763660865,
+                51.483073061902296
+              ],
+              [
+                -0.0752253103701215,
+                51.483138902119634
+              ],
+              [
+                -0.07493734998485325,
+                51.483240708662436
+              ],
+              [
+                -0.07468573980210308,
+                51.48337476468626
+              ],
+              [
+                -0.07447966625880034,
+                51.483536175916264
+              ],
+              [
+                -0.07432665351938529,
+                51.483719049304945
+              ],
+              [
+                -0.0742322887326799,
+                51.48391670815698
+              ],
+              [
+                -0.07415527994534045,
+                51.484161707043235
+              ],
+              [
+                -0.07412307707964114,
+                51.484378824770474
+              ],
+              [
+                -0.07416161468926359,
+                51.48459554194685
+              ],
+              [
+                -0.07426932058476096,
+                51.484803011794625
+              ],
+              [
+                -0.07444179886249265,
+                51.48499276491181
+              ],
+              [
+                -0.074672009221287,
+                51.48515705503473
+              ],
+              [
+                -0.07495055427489787,
+                51.485289175294774
+              ],
+              [
+                -0.0752660631451402,
+                51.485383732052064
+              ],
+              [
+                -0.07560565568040607,
+                51.48543686512013
+              ],
+              [
+                -0.07563865643674306,
+                51.48543986519039
+              ],
+              [
+                -0.07597871334451682,
+                51.485449737443865
+              ],
+              [
+                -0.07606783741935134,
+                51.48544134015071
+              ],
+              [
+                -0.07610903686861933,
+                51.48544811115062
+              ],
+              [
+                -0.07636504268921902,
+                51.48547411175793
+              ],
+              [
+                -0.07670939164615519,
+                51.48548741590888
+              ],
+              [
+                -0.07705114879260505,
+                51.48545797882999
+              ],
+              [
+                -0.07737676854911488,
+                51.48538696726444
+              ],
+              [
+                -0.0776733450725096,
+                51.48527719575741
+              ],
+              [
+                -0.07792912386259696,
+                51.48513301507986
+              ],
+              [
+                -0.0781339676929286,
+                51.48496013975597
+              ],
+              [
+                -0.0782797583884334,
+                51.48476542153637
+              ],
+              [
+                -0.07836071852417716,
+                51.48455657780224
+              ],
+              [
+                -0.07840771069514788,
+                51.48434457711614
+              ]
+            ]
+          ]
+        }
+      },
+      "proposal.site.area": 1232.22,
+      "proposal.site.hectares": 0.123222,
+      "drawBoundary.action": "Accepted the title boundary",
+      "proposal.site.area.half": 616.11,
+      "proposal.site.area.hectares.double": 0.246444,
+      "_constraints": [
+        {
+          "sourceRequest": "https://www.planning.data.gov.uk/entity.json?entries=current&geometry=MULTIPOLYGON+%28%28%28-0.076691+51.484197%2C+-0.075933+51.484124%2C+-0.075856+51.484369%2C+-0.075889+51.484372%2C+-0.0759+51.484324%2C+-0.076391+51.484369%2C+-0.076388+51.484383%2C+-0.076644+51.484409%2C+-0.076691+51.484197%29%29%29&geometry_relation=intersects&exclude_field=geometry%2Cpoint&limit=100&dataset=article-4-direction-area&dataset=central-activities-zone&dataset=brownfield-land&dataset=brownfield-site&dataset=area-of-outstanding-natural-beauty&dataset=conservation-area&dataset=green-belt&dataset=national-park&dataset=world-heritage-site&dataset=world-heritage-site-buffer-zone&dataset=flood-risk-zone&dataset=listed-building&dataset=listed-building-outline&dataset=scheduled-monument&dataset=ancient-woodland&dataset=ramsar&dataset=special-area-of-conservation&dataset=special-protection-area&dataset=site-of-special-scientific-interest&dataset=park-and-garden&dataset=tree&dataset=tree-preservation-order&dataset=tree-preservation-zone",
+          "constraints": {
+            "listed": {
+              "fn": "listed",
+              "value": true,
+              "text": "is, or is within, a Listed Building",
+              "data": [
+                {
+                  "entry-date": "2023-08-16",
+                  "start-date": "1954-06-30",
+                  "end-date": "",
+                  "entity": 42115431,
+                  "name": "New Peckham mosque (former church of St Mark)",
+                  "dataset": "listed-building-outline",
+                  "typology": "geography",
+                  "reference": "470793",
+                  "prefix": "listed-building-outline",
+                  "organisation-entity": "329",
+                  "document-url": "https://geomap.southwark.gov.uk/connect/analyst/Includes/ListedBuildings/SwarkLB205.pdf",
+                  "listed-building": "470793",
+                  "documentation-url": "https://geo.southwark.gov.uk/connect/analyst/Includes/ListedBuildings/SwarkLB205.pdf"
+                }
+              ],
+              "category": "Heritage and conservation"
+            },
+            "designated.conservationArea": {
+              "fn": "designated.conservationArea",
+              "value": true,
+              "text": "is in a Conservation Area",
+              "data": [
+                {
+                  "entry-date": "2024-07-11",
+                  "start-date": "1980-02-05",
+                  "end-date": "",
+                  "entity": 44010233,
+                  "name": "Cobourg Road",
+                  "dataset": "conservation-area",
+                  "typology": "geography",
+                  "reference": "19",
+                  "prefix": "conservation-area",
+                  "organisation-entity": "329",
+                  "document-url": "https://www.southwark.gov.uk/planning-and-building-control/design-and-conservation/conservation-areas?chapter=10",
+                  "designation-date": "1980-02-05",
+                  "documentation-url": "https://www.southwark.gov.uk/planning-and-building-control/design-and-conservation/conservation-areas?chapter=10"
+                }
+              ],
+              "category": "Heritage and conservation"
+            },
+            "flood": {
+              "fn": "flood",
+              "value": true,
+              "text": "is in a Flood Risk Zone",
+              "data": [
+                {
+                  "entry-date": "2023-08-24",
+                  "start-date": "",
+                  "end-date": "",
+                  "entity": 65106806,
+                  "name": "",
+                  "dataset": "flood-risk-zone",
+                  "typology": "geography",
+                  "reference": "106807",
+                  "prefix": "flood-risk-zone",
+                  "organisation-entity": "600009",
+                  "flood-risk-type": "Tidal Models",
+                  "flood-risk-level": "3"
+                },
+                {
+                  "entry-date": "2023-08-24",
+                  "start-date": "",
+                  "end-date": "",
+                  "entity": 65232137,
+                  "name": "",
+                  "dataset": "flood-risk-zone",
+                  "typology": "geography",
+                  "reference": "232138",
+                  "prefix": "flood-risk-zone",
+                  "organisation-entity": "600009",
+                  "flood-risk-type": "Tidal Models",
+                  "flood-risk-level": "2"
+                }
+              ],
+              "category": "Flooding"
+            },
+            "tpo": {
+              "fn": "tpo",
+              "value": true,
+              "text": "is in a Tree Preservation Order (TPO) Zone",
+              "data": [
+                {
+                  "entry-date": "2021-02-02",
+                  "start-date": "2021-02-02",
+                  "end-date": "",
+                  "entity": 7002050495,
+                  "name": "103 Coburg Road, SE5 0HU",
+                  "dataset": "tree",
+                  "typology": "geography",
+                  "reference": "537",
+                  "prefix": "tree",
+                  "organisation-entity": "329",
+                  "tree-preservation-order": "606",
+                  "tree-preservation-order-tree": "Individual"
+                }
+              ],
+              "category": "Trees"
+            },
+            "articleFour": {
+              "fn": "articleFour",
+              "value": false,
+              "text": "is not in an Article 4 direction area",
+              "category": "General policy"
+            },
+            "articleFour.caz": {
+              "fn": "articleFour.caz",
+              "value": false,
+              "text": "is not in the Central Activities Zone",
+              "category": "General policy"
+            },
+            "brownfieldSite": {
+              "fn": "brownfieldSite",
+              "value": false,
+              "text": "is not on Brownfield land",
+              "category": "General policy"
+            },
+            "designated.AONB": {
+              "fn": "designated.AONB",
+              "value": false,
+              "text": "is not in an Area of Outstanding Natural Beauty",
+              "category": "Heritage and conservation"
+            },
+            "greenBelt": {
+              "fn": "greenBelt",
+              "value": false,
+              "text": "is not in a Green Belt",
+              "category": "General policy"
+            },
+            "designated.nationalPark": {
+              "fn": "designated.nationalPark",
+              "value": false,
+              "text": "is not in a National Park",
+              "category": "Heritage and conservation"
+            },
+            "designated.nationalPark.broads": {
+              "fn": "designated.nationalPark.broads",
+              "value": false
+            },
+            "designated.WHS": {
+              "fn": "designated.WHS",
+              "value": false,
+              "text": "is not an UNESCO World Heritage Site",
+              "category": "Heritage and conservation"
+            },
+            "monument": {
+              "fn": "monument",
+              "value": false,
+              "text": "is not the site of a Scheduled Monument",
+              "category": "Heritage and conservation"
+            },
+            "nature.ASNW": {
+              "fn": "nature.ASNW",
+              "value": false,
+              "text": "is not in an Ancient Semi-Natural Woodland (ASNW)",
+              "category": "Ecology"
+            },
+            "nature.ramsarSite": {
+              "fn": "nature.ramsarSite",
+              "value": false,
+              "text": "is not in a Ramsar Site",
+              "category": "Ecology"
+            },
+            "nature.SAC": {
+              "fn": "nature.SAC",
+              "value": false,
+              "text": "is not in a Special Area of Conservation (SAC)",
+              "category": "Ecology"
+            },
+            "nature.SPA": {
+              "fn": "nature.SPA",
+              "value": false,
+              "text": "is not in a Special Protection Area (SPA)",
+              "category": "Ecology"
+            },
+            "nature.SSSI": {
+              "fn": "nature.SSSI",
+              "value": false,
+              "text": "is not a Site of Special Scientific Interest (SSSI)",
+              "category": "Ecology"
+            },
+            "registeredPark": {
+              "fn": "registeredPark",
+              "value": false,
+              "text": "is not in a Historic Park or Garden",
+              "category": "Heritage and conservation"
+            },
+            "designated": {
+              "value": true
+            },
+            "flood.zoneTwo": {
+              "fn": "flood.zoneTwo",
+              "value": true
+            },
+            "flood.zoneThree": {
+              "fn": "flood.zoneThree",
+              "value": true
+            },
+            "listed.gradeOne": {
+              "fn": "listed.gradeOne",
+              "value": false
+            },
+            "listed.gradeTwo": {
+              "fn": "listed.gradeTwo",
+              "value": false
+            },
+            "listed.gradeTwoStar": {
+              "fn": "listed.gradeTwoStar",
+              "value": false
+            }
+          },
+          "metadata": {
+            "articleFour": {
+              "entry-date": "",
+              "start-date": "",
+              "end-date": "",
+              "collection": "article-4-direction",
+              "dataset": "article-4-direction-area",
+              "description": "Orders made by the local planning authority to remove all or some of the permitted development rights on a site in order to protect it",
+              "name": "Article 4 direction area",
+              "plural": "Article 4 direction areas",
+              "prefix": "",
+              "text": "A local planning authority may create an [article 4 direction](https://www.gov.uk/guidance/when-is-permission-required#article-4-direction) to alter or remove [permitted development rights](https://www.gov.uk/government/publications/permitted-development-rights-for-householders-technical-guidance) from a building or area.\n\nEach [article 4 direction](/dataset/article-4-direction) may apply to one or more article 4 direction areas.",
+              "typology": "geography",
+              "wikidata": "",
+              "wikipedia": "",
+              "entities": "",
+              "themes": [
+                "heritage"
+              ],
+              "entity-count": {
+                "dataset": "article-4-direction-area",
+                "count": 2757
+              },
+              "paint-options": "",
+              "attribution": "crown-copyright",
+              "attribution-text": "© Crown copyright and database right 2025",
+              "licence": "ogl3",
+              "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+              "consideration": "article-4-directions",
+              "github-discussion": 30,
+              "entity-minimum": 7010000000,
+              "entity-maximum": 7019999999,
+              "phase": "beta",
+              "realm": "dataset",
+              "replacement-dataset": "",
+              "version": "3.0"
+            },
+            "articleFour.caz": {
+              "entry-date": "",
+              "start-date": "",
+              "end-date": "",
+              "collection": "central-activities-zone",
+              "dataset": "central-activities-zone",
+              "description": "",
+              "name": "Central activities zone",
+              "plural": "Central activities zones",
+              "prefix": "",
+              "text": "The [Greater London Authority](https://www.london.gov.uk/) (GLA) designates a central area of London with [implications for planning](https://www.london.gov.uk/what-we-do/planning/implementing-london-plan/london-plan-guidance-and-spgs/central-activities-zone)\nThis dataset combines data provided by the GLA with the boundary from the individual London boroughs.",
+              "typology": "geography",
+              "wikidata": "",
+              "wikipedia": "",
+              "entities": "",
+              "themes": [
+                "development"
+              ],
+              "entity-count": {
+                "dataset": "central-activities-zone",
+                "count": 10
+              },
+              "paint-options": "",
+              "attribution": "crown-copyright",
+              "attribution-text": "© Crown copyright and database right 2025",
+              "licence": "ogl3",
+              "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+              "consideration": "central-activty-zones",
+              "github-discussion": "",
+              "entity-minimum": 2200000,
+              "entity-maximum": 2299999,
+              "phase": "beta",
+              "realm": "dataset",
+              "replacement-dataset": "",
+              "version": "1.0"
+            },
+            "brownfieldSite": {
+              "entry-date": "",
+              "start-date": "",
+              "end-date": "",
+              "collection": "brownfield-site",
+              "dataset": "brownfield-site",
+              "description": "",
+              "name": "Brownfield site",
+              "plural": "Brownfield sites",
+              "prefix": "",
+              "text": "This is an experimental dataset of the boundaries of brownfield sites found on [data.gov.uk](https://www.data.gov.uk/search?q=brownfield)\nand local planning authority web sites.\nWe expect to combine this dataset with the [brownfield land](/dataset/brownfield-land) dataset in the near future.",
+              "typology": "geography",
+              "wikidata": "Q896586",
+              "wikipedia": "Brownfield_land",
+              "entities": "",
+              "themes": [
+                "development"
+              ],
+              "entity-count": {
+                "dataset": "brownfield-site",
+                "count": 2852
+              },
+              "paint-options": {
+                "colour": "#745729"
+              },
+              "attribution": "crown-copyright",
+              "attribution-text": "© Crown copyright and database right 2025",
+              "licence": "ogl3",
+              "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+              "consideration": "brownfield-land",
+              "github-discussion": 28,
+              "entity-minimum": 1800000,
+              "entity-maximum": 1899999,
+              "phase": "alpha",
+              "realm": "dataset",
+              "replacement-dataset": "",
+              "version": "1.0"
+            },
+            "designated.AONB": {
+              "entry-date": "",
+              "start-date": "",
+              "end-date": "",
+              "collection": "area-of-outstanding-natural-beauty",
+              "dataset": "area-of-outstanding-natural-beauty",
+              "description": "Land protected by law to conserve and enhance its natural beauty",
+              "name": "Area of outstanding natural beauty",
+              "plural": "Areas of outstanding natural beauty",
+              "prefix": "",
+              "text": "An area of outstanding natural beauty (AONB) as designated by [Natural England](https://www.gov.uk/government/organisations/natural-england).\n\nNatural England provides [guidance](https://www.gov.uk/guidance/protected-sites-and-areas-how-to-review-planning-applications) to help local authorities decide on planning applications in protected sites and areas.",
+              "typology": "geography",
+              "wikidata": "Q174945",
+              "wikipedia": "Area_of_Outstanding_Natural_Beauty",
+              "entities": "",
+              "themes": [
+                "environment"
+              ],
+              "entity-count": {
+                "dataset": "area-of-outstanding-natural-beauty",
+                "count": 34
+              },
+              "paint-options": {
+                "colour": "#d53880"
+              },
+              "attribution": "natural-england",
+              "attribution-text": "© Natural England copyright. Contains Ordnance Survey data © Crown copyright and database right 2025.",
+              "licence": "ogl3",
+              "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+              "consideration": "areas-of-outstanding-natural-beauty",
+              "github-discussion": 31,
+              "entity-minimum": 1000000,
+              "entity-maximum": 1099999,
+              "phase": "live",
+              "realm": "dataset",
+              "replacement-dataset": "",
+              "version": "1.0"
+            },
+            "designated.conservationArea": {
+              "entry-date": "",
+              "start-date": "",
+              "end-date": "",
+              "collection": "conservation-area",
+              "dataset": "conservation-area",
+              "description": "Special architectural or historic interest, the character or appearance of which it is desirable to preserve or enhance",
+              "name": "Conservation area",
+              "plural": "Conservation areas",
+              "prefix": "",
+              "text": "Local planning authorities are responsible for designating conservation areas, though [Historic England](https://historicengland.org.uk/) and the Secretary of State also have powers to create them.\n\nThis dataset also contains the boundaries of conservation areas from Historic England, as well as other data found on [data.gov.uk](https://www.data.gov.uk/search?q=conservation+area) and currently contains a number of duplicate areas we are working to remove.\n\nWe are also [working with a group of local planning authorities](/about/) to help them publish their conservation areas, and to develop a [data specification for conservation areas](https://www.digital-land.info/guidance/specifications/conservation-area).\n\nHistoric England provide [guidance](https://historicengland.org.uk/advice/your-home/owning-historic-property/conservation-area/) to help householders understand the implications of living in a conservation area for planning applications.",
+              "typology": "geography",
+              "wikidata": "Q5162904",
+              "wikipedia": "Conservation_area_(United_Kingdom)",
+              "entities": "",
+              "themes": [
+                "heritage"
+              ],
+              "entity-count": {
+                "dataset": "conservation-area",
+                "count": 11167
+              },
+              "paint-options": {
+                "colour": "#78AA00"
+              },
+              "attribution": "historic-england",
+              "attribution-text": "© Historic England 2025. Contains Ordnance Survey data © Crown copyright and database right 2025.\nThe Historic England GIS Data contained in this material was obtained on [date].\nThe most publicly available up to date Historic England GIS Data can be obtained from [HistoricEngland.org.uk](https://historicengland.org.uk).",
+              "licence": "ogl3",
+              "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+              "consideration": "conservation-areas",
+              "github-discussion": 33,
+              "entity-minimum": 44000000,
+              "entity-maximum": 44999999,
+              "phase": "beta",
+              "realm": "dataset",
+              "replacement-dataset": "",
+              "version": "3.0"
+            },
+            "greenBelt": {
+              "entry-date": "",
+              "start-date": "",
+              "end-date": "",
+              "collection": "green-belt",
+              "dataset": "green-belt",
+              "description": "",
+              "name": "Green belt",
+              "plural": "Green belt",
+              "prefix": "",
+              "text": "Boundaries for land designated by a local planning authority as being [green belt](https://www.gov.uk/guidance/green-belt),\ngrouped using the [greenbelt core](/dataset/greenbelt-core) category.\nThis data is compiled by the Department for Levelling Up, Housing and Communities for the purposes of gathering [green belt statistics](https://www.gov.uk/government/collections/green-belt-statistics).",
+              "typology": "geography",
+              "wikidata": "Q2734873",
+              "wikipedia": "Green_belt_(United_Kingdom)",
+              "entities": "",
+              "themes": [
+                "environment"
+              ],
+              "entity-count": {
+                "dataset": "green-belt",
+                "count": 185
+              },
+              "paint-options": {
+                "colour": "#85994b"
+              },
+              "attribution": "os-open-data",
+              "attribution-text": "Your use of OS OpenData is subject to the terms at http://os.uk/opendata/licence\nContains Ordnance Survey data © Crown copyright and database right 2025",
+              "licence": "ogl3",
+              "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+              "consideration": "greenbelt",
+              "github-discussion": 45,
+              "entity-minimum": 610000,
+              "entity-maximum": 610999,
+              "phase": "beta",
+              "realm": "dataset",
+              "replacement-dataset": "",
+              "version": "1.0"
+            },
+            "designated.nationalPark": {
+              "entry-date": "",
+              "start-date": "",
+              "end-date": "",
+              "collection": "national-park",
+              "dataset": "national-park",
+              "description": "",
+              "name": "National park",
+              "plural": "National parks",
+              "prefix": "statistical-geography",
+              "text": "The administrative boundaries of [national park authorities](/dataset/national-park-authority) in England as provided by the ONS for the purposes of producing statistics.",
+              "typology": "geography",
+              "wikidata": "Q60256727",
+              "wikipedia": "National_park",
+              "entities": "",
+              "themes": [
+                "heritage"
+              ],
+              "entity-count": {
+                "dataset": "national-park",
+                "count": 10
+              },
+              "paint-options": {
+                "colour": "#3DA52C"
+              },
+              "attribution": "ons-boundary",
+              "attribution-text": "Source: Office for National Statistics licensed under the Open Government Licence v.3.0\nContains OS data © Crown copyright and database right 2025",
+              "licence": "ogl3",
+              "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+              "consideration": "national-parks-and-the-broads",
+              "github-discussion": "",
+              "entity-minimum": 520000,
+              "entity-maximum": 520999,
+              "phase": "beta",
+              "realm": "dataset",
+              "replacement-dataset": "",
+              "version": "1.0"
+            },
+            "designated.WHS": {
+              "entry-date": "",
+              "start-date": "",
+              "end-date": "",
+              "collection": "historic-england",
+              "dataset": "world-heritage-site-buffer-zone",
+              "description": "",
+              "name": "World heritage site buffer zone",
+              "plural": "World heritage site buffer zones",
+              "prefix": "",
+              "text": "A [World Heritage Site](/dataset/world-heritage-site) may have a [buffer zone](https://whc.unesco.org/en/series/25/) with implications for planning.",
+              "typology": "geography",
+              "wikidata": "Q9259",
+              "wikipedia": "World_Heritage_Site",
+              "entities": "",
+              "themes": [
+                "heritage"
+              ],
+              "entity-count": {
+                "dataset": "world-heritage-site-buffer-zone",
+                "count": 9
+              },
+              "paint-options": {
+                "colour": "#EB1EE5",
+                "opacity": 0.2
+              },
+              "attribution": "historic-england",
+              "attribution-text": "© Historic England 2025. Contains Ordnance Survey data © Crown copyright and database right 2025.\nThe Historic England GIS Data contained in this material was obtained on [date].\nThe most publicly available up to date Historic England GIS Data can be obtained from [HistoricEngland.org.uk](https://historicengland.org.uk).",
+              "licence": "ogl3",
+              "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+              "consideration": "world-heritage-sites",
+              "github-discussion": "",
+              "entity-minimum": 16110000,
+              "entity-maximum": 16129999,
+              "phase": "beta",
+              "realm": "dataset",
+              "replacement-dataset": "",
+              "version": "1.0"
+            },
+            "flood": {
+              "entry-date": "",
+              "start-date": "",
+              "end-date": "",
+              "collection": "flood-risk-zone",
+              "dataset": "flood-risk-zone",
+              "description": "Area identified as being at risk of flooding from rivers or the sea",
+              "name": "Flood risk zone",
+              "plural": "Flood risk zones",
+              "prefix": "",
+              "text": "Flood zones are a guide produced by the Environment Agency to demonstrate the probability of river and sea flooding in areas across England. Flood zones are based on the likelihood of an area flooding, with flood zone 1 areas least likely to flood and flood zone 3 areas more likely to flood. \n\nThe flood zones were produced to help developers, councils and communities understand the flood risks present in specific locations or regions. Despite being a very useful indicator of an area’s flood risk, the zones cannot tell you whether a location will definitely flood or to what severity.",
+              "typology": "geography",
+              "wikidata": "",
+              "wikipedia": "",
+              "entities": "",
+              "themes": [
+                "environment"
+              ],
+              "entity-count": {
+                "dataset": "flood-risk-zone",
+                "count": 550621
+              },
+              "paint-options": "",
+              "attribution": "crown-copyright",
+              "attribution-text": "© Crown copyright and database right 2025",
+              "licence": "ogl3",
+              "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+              "consideration": "flood-risk-zones",
+              "github-discussion": 46,
+              "entity-minimum": 65000000,
+              "entity-maximum": 65999999,
+              "phase": "live",
+              "realm": "dataset",
+              "replacement-dataset": "",
+              "version": "1.0"
+            },
+            "listed": {
+              "entry-date": "",
+              "start-date": "",
+              "end-date": "",
+              "collection": "listed-building",
+              "dataset": "listed-building-outline",
+              "description": "boundary of a listed building",
+              "name": "Listed building outline",
+              "plural": "Listed building outlines",
+              "prefix": "",
+              "text": "The geospatial boundary for [listed buildings](https://historicengland.org.uk/listing/what-is-designation/listed-buildings) as designated by [Historic England](https://historicengland.org.uk/) as collected from local planning authorities.\n\nWe are [working with a group of local planning authorities](/about/) to help them publish their data to inform planning decisions, and to develop a [data specification for listed building outlines](https://www.digital-land.info/guidance/specifications/listed-building).\n\nWe expect to eventually merge this dataset with the [listed building](/dataset/listed-building) dataset.",
+              "typology": "geography",
+              "wikidata": "Q570600",
+              "wikipedia": "Listed_building",
+              "entities": "",
+              "themes": [
+                "heritage"
+              ],
+              "entity-count": {
+                "dataset": "listed-building-outline",
+                "count": 37369
+              },
+              "paint-options": {
+                "colour": "#F9C744"
+              },
+              "attribution": "crown-copyright",
+              "attribution-text": "© Crown copyright and database right 2025",
+              "licence": "ogl3",
+              "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+              "consideration": "listed-buildings",
+              "github-discussion": 44,
+              "entity-minimum": 42100000,
+              "entity-maximum": 43099999,
+              "phase": "alpha",
+              "realm": "dataset",
+              "replacement-dataset": "",
+              "version": "1.0"
+            },
+            "monument": {
+              "entry-date": "",
+              "start-date": "",
+              "end-date": "",
+              "collection": "historic-england",
+              "dataset": "scheduled-monument",
+              "description": "",
+              "name": "Scheduled monument",
+              "plural": "Scheduled monuments",
+              "prefix": "",
+              "text": "Historic buildings or sites such as Roman remains, burial mounds, castles, bridges, earthworks, the remains of deserted villages and industrial sites can be designated scheduled monuments by the Secretary of State for [Digital, Culture, Media and Sport](https://www.gov.uk/government/organisations/department-for-digital-culture-media-sport). \n\nThis list of scheduled monuments is kept and maintained by [Historic England](https://historicengland.org.uk/).",
+              "typology": "geography",
+              "wikidata": "Q219538",
+              "wikipedia": "Scheduled_monument",
+              "entities": "",
+              "themes": [
+                "heritage"
+              ],
+              "entity-count": {
+                "dataset": "scheduled-monument",
+                "count": 19999
+              },
+              "paint-options": {
+                "colour": "#0F9CDA"
+              },
+              "attribution": "historic-england",
+              "attribution-text": "© Historic England 2025. Contains Ordnance Survey data © Crown copyright and database right 2025.\nThe Historic England GIS Data contained in this material was obtained on [date].\nThe most publicly available up to date Historic England GIS Data can be obtained from [HistoricEngland.org.uk](https://historicengland.org.uk).",
+              "licence": "ogl3",
+              "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+              "consideration": "scheduled-monuments",
+              "github-discussion": "",
+              "entity-minimum": 13900000,
+              "entity-maximum": 13999999,
+              "phase": "beta",
+              "realm": "dataset",
+              "replacement-dataset": "",
+              "version": "1.0"
+            },
+            "nature.ASNW": {
+              "entry-date": "",
+              "start-date": "",
+              "end-date": "",
+              "collection": "ancient-woodland",
+              "dataset": "ancient-woodland",
+              "description": "An area that’s been wooded continuously since at least 1600 AD",
+              "name": "Ancient woodland",
+              "plural": "Ancient woodlands",
+              "prefix": "",
+              "text": "An area designated as ancient woodland by Natural England.\n\nNatural England and Forestry Commission [Guidance](https://www.gov.uk/guidance/ancient-woodland-and-veteran-trees-protection-surveys-licences)  is used in planning decisions.",
+              "typology": "geography",
+              "wikidata": "Q3078732",
+              "wikipedia": "Ancient_woodland",
+              "entities": "",
+              "themes": [
+                "environment"
+              ],
+              "entity-count": {
+                "dataset": "ancient-woodland",
+                "count": 44373
+              },
+              "paint-options": {
+                "colour": "#00703c",
+                "opacity": 0.2
+              },
+              "attribution": "natural-england",
+              "attribution-text": "© Natural England copyright. Contains Ordnance Survey data © Crown copyright and database right 2025.",
+              "licence": "ogl3",
+              "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+              "consideration": "ancient-woodlands",
+              "github-discussion": 32,
+              "entity-minimum": 110000000,
+              "entity-maximum": 129999999,
+              "phase": "live",
+              "realm": "dataset",
+              "replacement-dataset": "",
+              "version": "1.0"
+            },
+            "nature.ramsarSite": {
+              "entry-date": "",
+              "start-date": "",
+              "end-date": "",
+              "collection": "ramsar",
+              "dataset": "ramsar",
+              "description": "",
+              "name": "Ramsar site",
+              "plural": "Ramsar sites",
+              "prefix": "",
+              "text": "An internationally protected site listed as a wetland of international importance.\nRamsar sites are designated by [UNESCO](https://en.unesco.org/) and managed by [Natural England](https://www.gov.uk/government/organisations/natural-england).\n\nNatural England provides [guidance ](https://www.gov.uk/guidance/protected-sites-and-areas-how-to-review-planning-applications) to help local authorities decide on planning applications in protected sites and areas.",
+              "typology": "geography",
+              "wikidata": "",
+              "wikipedia": "",
+              "entities": "",
+              "themes": [
+                "environment"
+              ],
+              "entity-count": {
+                "dataset": "ramsar",
+                "count": 73
+              },
+              "paint-options": {
+                "colour": "#7fcdff"
+              },
+              "attribution": "natural-england",
+              "attribution-text": "© Natural England copyright. Contains Ordnance Survey data © Crown copyright and database right 2025.",
+              "licence": "ogl3",
+              "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+              "consideration": "ramsar",
+              "github-discussion": 41,
+              "entity-minimum": 612000,
+              "entity-maximum": 619999,
+              "phase": "beta",
+              "realm": "dataset",
+              "replacement-dataset": "",
+              "version": "1.0"
+            },
+            "nature.SAC": {
+              "entry-date": "",
+              "start-date": "",
+              "end-date": "",
+              "collection": "special-area-of-conservation",
+              "dataset": "special-area-of-conservation",
+              "description": "",
+              "name": "Special area of conservation",
+              "plural": "Special areas of conservation",
+              "prefix": "",
+              "text": "Special areas of conservation (SACs) are area of land which have been designated by\n[DEFRA](https://www.gov.uk/government/organisations/department-for-environment-food-rural-affairs),\nwith advice from the [Joint Nature Conservation Committee](https://jncc.gov.uk/),\nto protect specific habitats and species.\n\nDEFRA and [Natural England](https://www.gov.uk/government/organisations/natural-england) publish\n[guidance](https://www.gov.uk/guidance/protected-sites-and-areas-how-to-review-planning-applications)\non how to review planning applications in protected sites and areas.",
+              "typology": "geography",
+              "wikidata": "Q1191622",
+              "wikipedia": "Special_Area_of_Conservation",
+              "entities": "",
+              "themes": [
+                "environment"
+              ],
+              "entity-count": {
+                "dataset": "special-area-of-conservation",
+                "count": 260
+              },
+              "paint-options": {
+                "colour": "#7A8705"
+              },
+              "attribution": "natural-england",
+              "attribution-text": "© Natural England copyright. Contains Ordnance Survey data © Crown copyright and database right 2025.",
+              "licence": "ogl3",
+              "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+              "consideration": "special-areas-of-conservation",
+              "github-discussion": "",
+              "entity-minimum": 14800000,
+              "entity-maximum": 14899999,
+              "phase": "beta",
+              "realm": "dataset",
+              "replacement-dataset": "",
+              "version": "1.0"
+            },
+            "nature.SPA": {
+              "entry-date": "",
+              "start-date": "",
+              "end-date": "",
+              "collection": "special-protection-area",
+              "dataset": "special-protection-area",
+              "description": "",
+              "name": "Special protection area",
+              "plural": "Special protection areas",
+              "prefix": "",
+              "text": "[Special protection areas](https://naturalengland-defra.opendata.arcgis.com/maps/Defra::special-protection-areas-england/about) is an area designated \nfor the protection of birds and wildlife. This dataset is provided by [Natural England](https://www.gov.uk/government/organisations/natural-england).",
+              "typology": "geography",
+              "wikidata": "",
+              "wikipedia": "",
+              "entities": "",
+              "themes": [
+                "environment"
+              ],
+              "entity-count": {
+                "dataset": "special-protection-area",
+                "count": 88
+              },
+              "paint-options": "",
+              "attribution": "natural-england",
+              "attribution-text": "© Natural England copyright. Contains Ordnance Survey data © Crown copyright and database right 2025.",
+              "licence": "ogl3",
+              "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+              "consideration": "special-protection-areas",
+              "github-discussion": "",
+              "entity-minimum": 14900000,
+              "entity-maximum": 14999999,
+              "phase": "beta",
+              "realm": "dataset",
+              "replacement-dataset": "",
+              "version": "1.0"
+            },
+            "nature.SSSI": {
+              "entry-date": "",
+              "start-date": "",
+              "end-date": "",
+              "collection": "site-of-special-scientific-interest",
+              "dataset": "site-of-special-scientific-interest",
+              "description": "",
+              "name": "Site of special scientific interest",
+              "plural": "Sites of special scientific interest",
+              "prefix": "",
+              "text": "Sites of special scientific interest (SSSI) are nationally protected sites that have features such as wildlife or geology. \n\nSSSIs are designated by [Natural England](https://www.gov.uk/government/organisations/natural-england).\nThere is [guidance](https://www.gov.uk/guidance/protected-areas-sites-of-special-scientific-interest) to help local authorities decide on planning applications in protected SSSIs.",
+              "typology": "geography",
+              "wikidata": "Q422211",
+              "wikipedia": "Site_of_Special_Scientific_Interest",
+              "entities": "",
+              "themes": [
+                "environment"
+              ],
+              "entity-count": {
+                "dataset": "site-of-special-scientific-interest",
+                "count": 4129
+              },
+              "paint-options": {
+                "colour": "#308fac"
+              },
+              "attribution": "natural-england",
+              "attribution-text": "© Natural England copyright. Contains Ordnance Survey data © Crown copyright and database right 2025.",
+              "licence": "ogl3",
+              "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+              "consideration": "sites-of-special-scientific-interest",
+              "github-discussion": "",
+              "entity-minimum": 14500000,
+              "entity-maximum": 14599999,
+              "phase": "beta",
+              "realm": "dataset",
+              "replacement-dataset": "",
+              "version": "1.0"
+            },
+            "registeredPark": {
+              "entry-date": "",
+              "start-date": "",
+              "end-date": "",
+              "collection": "historic-england",
+              "dataset": "park-and-garden",
+              "description": "",
+              "name": "Historic parks and gardens",
+              "plural": "Parks and gardens",
+              "prefix": "",
+              "text": "Historic parks and gardens as listed by [Historic England](https://historicengland.org.uk/) in the [Register of Parks and Gardens of Special Historic Interest](https://historicengland.org.uk/listing/what-is-designation/registered-parks-and-gardens/).",
+              "typology": "geography",
+              "wikidata": "Q6975250",
+              "wikipedia": "Register_of_Historic_Parks_and_Gardens_of_Special_Historic_Interest_in_England",
+              "entities": "",
+              "themes": [
+                "environment",
+                "heritage"
+              ],
+              "entity-count": {
+                "dataset": "park-and-garden",
+                "count": 1716
+              },
+              "paint-options": {
+                "colour": "#0EB951"
+              },
+              "attribution": "historic-england",
+              "attribution-text": "© Historic England 2025. Contains Ordnance Survey data © Crown copyright and database right 2025.\nThe Historic England GIS Data contained in this material was obtained on [date].\nThe most publicly available up to date Historic England GIS Data can be obtained from [HistoricEngland.org.uk](https://historicengland.org.uk).",
+              "licence": "ogl3",
+              "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+              "consideration": "",
+              "github-discussion": "",
+              "entity-minimum": 11100000,
+              "entity-maximum": 11199999,
+              "phase": "beta",
+              "realm": "dataset",
+              "replacement-dataset": "",
+              "version": "1.0"
+            },
+            "tpo": {
+              "entry-date": "",
+              "start-date": "",
+              "end-date": "",
+              "collection": "tree-preservation-order",
+              "dataset": "tree-preservation-zone",
+              "description": "An area covered by a tree preservation order",
+              "name": "Tree preservation zone",
+              "plural": "Trees preservation zones",
+              "prefix": "",
+              "text": "A Tree Preservation Order (TPO) can be placed on single trees, groups of trees and even whole woodlands. Tree Preservation Orders are made by local planning authorities following [guidance](https://www.gov.uk/guidance/tree-preservation-orders-and-trees-in-conservation-areas) provided by the [Ministry of Housing, Communities and Local Governments](https://www.gov.uk/government/organisations/ministry-of-housing-communities-local-government).\n\nEach [tree preservation order](/dataset/tree-preservation-order) may apply to a number of tree preservation order zones, and a number of individual [trees](/dataset/tree).\n\nThis dataset contains data from [a small group of local planning authorities](/about/) who we are working with to develop a [data specification for tree preservation orders](https://www.digital-land.info/guidance/specifications/tree-preservation-order).",
+              "typology": "geography",
+              "wikidata": "Q10884",
+              "wikipedia": "Tree",
+              "entities": "",
+              "themes": [
+                "environment"
+              ],
+              "entity-count": {
+                "dataset": "tree-preservation-zone",
+                "count": 26713
+              },
+              "paint-options": "",
+              "attribution": "crown-copyright",
+              "attribution-text": "© Crown copyright and database right 2025",
+              "licence": "ogl3",
+              "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+              "consideration": "tree-preservation-orders",
+              "github-discussion": 43,
+              "entity-minimum": 19100000,
+              "entity-maximum": 29099999,
+              "phase": "beta",
+              "realm": "dataset",
+              "replacement-dataset": "",
+              "version": "2.0"
+            }
+          },
+          "planxRequest": "https://api.editor.planx.uk/gis/testing?geom=MULTIPOLYGON+%28%28%28-0.076691+51.484197%2C+-0.075933+51.484124%2C+-0.075856+51.484369%2C+-0.075889+51.484372%2C+-0.0759+51.484324%2C+-0.076391+51.484369%2C+-0.076388+51.484383%2C+-0.076644+51.484409%2C+-0.076691+51.484197%29%29%29&vals=article4%2Carticle4.caz%2CbrownfieldSite%2Cdesignated.AONB%2Cdesignated.conservationArea%2CgreenBelt%2Cdesignated.nationalPark%2Cdesignated.nationalPark.broads%2Cdesignated.WHS%2Cflood%2Clisted%2Cmonument%2Cnature.ASNW%2Cnature.ramsarSite%2Cnature.SAC%2Cnature.SPA%2Cnature.SSSI%2CregisteredPark%2Ctpo%2Croad.classified&analytics=false"
+        },
+        {
+          "sourceRequest": "https://api.os.uk/features/v1/wfs?service=WFS&request=GetFeature&version=2.0.0&typeNames=Highways_RoadLink&outputFormat=GEOJSON&srsName=urn%3Aogc%3Adef%3Acrs%3AEPSG%3A%3A4326&count=1&filter=%0A++++%3Cogc%3AFilter%3E%0A++++++%3Cogc%3APropertyIsLike+wildCard%3D%22%25%22+singleChar%3D%22%23%22+escapeChar%3D%22%21%22%3E%0A++++++++%3Cogc%3APropertyName%3EFormsPartOf%3C%2Fogc%3APropertyName%3E%0A++++++++%3Cogc%3ALiteral%3E%25Street%23usrn22500531%25%3C%2Fogc%3ALiteral%3E%0A++++++%3C%2Fogc%3APropertyIsLike%3E%0A++++%3C%2Fogc%3AFilter%3E%0A++&",
+          "metadata": {
+            "road.classified": {
+              "name": "Classified road",
+              "plural": "Classified roads",
+              "text": "This will effect your project if you are looking to add a dropped kerb. It may also impact some agricultural or forestry projects within 25 metres of a classified road."
+            }
+          },
+          "constraints": {
+            "road.classified": {
+              "fn": "road.classified",
+              "value": false,
+              "text": "is not on a Classified Road",
+              "category": "General policy"
+            }
+          },
+          "planxRequest": "https://api.editor.planx.uk/roads?usrn=22500531"
+        }
+      ],
+      "planningConstraints.action": "Accepted all planning constraints",
+      "_nots": {
+        "property.constraints.planning": [
+          "articleFour",
+          "articleFour.caz",
+          "articleFour.buckinghamshire.osTwoSixTwo",
+          "articleFour.gateshead.saltwell.dFour",
+          "articleFour.newcastle.saintPetersBasinThree",
+          "brownfieldSite",
+          "designated.AONB",
+          "greenBelt",
+          "designated.nationalPark",
+          "designated.nationalPark.broads",
+          "designated.WHS",
+          "monument",
+          "nature.ASNW",
+          "nature.ramsarSite",
+          "nature.SAC",
+          "nature.SPA",
+          "nature.SSSI",
+          "registeredPark",
+          "listed.gradeOne",
+          "listed.gradeTwo",
+          "listed.gradeTwoStar",
+          "road.classified"
+        ]
+      },
+      "property.constraints.planning": [
+        "flood.zoneTwo",
+        "flood.zoneThree",
+        "listed.gradeTwo",
+        "designated",
+        "listed",
+        "flood",
+        "designated.conservationArea",
+        "tpo"
+      ],
+      "proposal.projectType": [
+        "alter.internal.loft"
+      ],
+      "flag": [
+        "LB-DE_MINIMIS",
+        "PRIOR_APPROVAL"
+      ]
+    }
+  },
+  breadcrumbs: {
+    "N8T7u2fedh": {
+      "auto": false,
+      "data": {
+        "_address": {
+          "uprn": "200003453172",
+          "usrn": "22500531",
+          "blpu_code": "2",
+          "latitude": 51.4842536,
+          "longitude": -0.0764166,
+          "organisation": null,
+          "sao": "FLAT 6",
+          "pao": "103",
+          "street": "COBOURG ROAD",
+          "town": "LONDON",
+          "postcode": "SE5 0HU",
+          "ward": "E05011109",
+          "x": 533660.36,
+          "y": 177898.47,
+          "planx_description": "Residential - Flat",
+          "planx_value": "residential.dwelling.flat",
+          "single_line_address": "FLAT 6, 103, COBOURG ROAD, LONDON, SOUTHWARK, SE5 0HU",
+          "title": "FLAT 6, 103, COBOURG ROAD, LONDON",
+          "source": "os"
+        },
+        "property.type": [
+          "residential.flat"
+        ],
+        "property.localAuthorityDistrict": [
+          "Southwark"
+        ],
+        "property.region": [
+          "London"
+        ],
+        "property.boundary": {
+          "geometry": {
+            "type": "MultiPolygon",
+            "coordinates": [
+              [
+                [
+                  [
+                    -0.076691,
+                    51.484197
+                  ],
+                  [
+                    -0.075933,
+                    51.484124
+                  ],
+                  [
+                    -0.075856,
+                    51.484369
+                  ],
+                  [
+                    -0.075889,
+                    51.484372
+                  ],
+                  [
+                    -0.0759,
+                    51.484324
+                  ],
+                  [
+                    -0.076391,
+                    51.484369
+                  ],
+                  [
+                    -0.076388,
+                    51.484383
+                  ],
+                  [
+                    -0.076644,
+                    51.484409
+                  ],
+                  [
+                    -0.076691,
+                    51.484197
+                  ]
+                ]
+              ]
+            ]
+          },
+          "type": "Feature",
+          "properties": {
+            "entry-date": "2024-05-06",
+            "start-date": "2011-08-25",
+            "end-date": "",
+            "entity": 12000601059,
+            "name": "",
+            "dataset": "title-boundary",
+            "typology": "geography",
+            "reference": "52725257",
+            "prefix": "title-boundary",
+            "organisation-entity": "13"
+          }
+        },
+        "property.boundary.area": 1232.22,
+        "property.boundary.area.hectares": 0.123222,
+        "findProperty.action": "Selected an existing address"
+      }
+    },
+    "6FL5k5zovo": {
+      "auto": true
+    },
+    "JkyukIyZ5r": {
+      "auto": true
+    },
+    "I03hRPF3ck": {
+      "auto": true,
+      "answers": [
+        "2Z4Ah7QPvE"
+      ]
+    },
+    "PXI9SWUFSM": {
+      "auto": false,
+      "data": {
+        "propertyInformation.action": "Accepted the property type"
+      }
+    },
+    "9YqHTuXVjs": {
+      "auto": false,
+      "data": {
+        "proposal.site": {
+          "geometry": {
+            "type": "MultiPolygon",
+            "coordinates": [
+              [
+                [
+                  [
+                    -0.076691,
+                    51.484197
+                  ],
+                  [
+                    -0.075933,
+                    51.484124
+                  ],
+                  [
+                    -0.075856,
+                    51.484369
+                  ],
+                  [
+                    -0.075889,
+                    51.484372
+                  ],
+                  [
+                    -0.0759,
+                    51.484324
+                  ],
+                  [
+                    -0.076391,
+                    51.484369
+                  ],
+                  [
+                    -0.076388,
+                    51.484383
+                  ],
+                  [
+                    -0.076644,
+                    51.484409
+                  ],
+                  [
+                    -0.076691,
+                    51.484197
+                  ]
+                ]
+              ]
+            ]
+          },
+          "type": "Feature",
+          "properties": {
+            "entry-date": "2024-05-06",
+            "start-date": "2011-08-25",
+            "end-date": "",
+            "entity": 12000601059,
+            "name": "",
+            "dataset": "title-boundary",
+            "typology": "geography",
+            "reference": "52725257",
+            "prefix": "title-boundary",
+            "organisation-entity": "13"
+          }
+        },
+        "proposal.site.buffered": {
+          "type": "Feature",
+          "properties": {
+            "entry-date": "2024-05-06",
+            "start-date": "2011-08-25",
+            "end-date": "",
+            "entity": 12000601059,
+            "name": "",
+            "dataset": "title-boundary",
+            "typology": "geography",
+            "reference": "52725257",
+            "prefix": "title-boundary",
+            "organisation-entity": "13"
+          },
+          "geometry": {
+            "type": "Polygon",
+            "coordinates": [
+              [
+                [
+                  -0.07840771069514788,
+                  51.48434457711614
+                ],
+                [
+                  -0.07842115842704286,
+                  51.48413536783419
+                ],
+                [
+                  -0.07836948082188315,
+                  51.48392847894068
+                ],
+                [
+                  -0.07825462393878962,
+                  51.48373169794115
+                ],
+                [
+                  -0.07808091182941154,
+                  51.483552431772814
+                ],
+                [
+                  -0.07785488367358213,
+                  51.48339742802321
+                ],
+                [
+                  -0.07758504757401118,
+                  51.48327252097795
+                ],
+                [
+                  -0.07728156028667897,
+                  51.483182412050674
+                ],
+                [
+                  -0.07695584494421384,
+                  51.48313049285461
+                ],
+                [
+                  -0.07619786224769512,
+                  51.48305749456187
+                ],
+                [
+                  -0.07586728536909972,
+                  51.4830455917509
+                ],
+                [
+                  -0.07553910763660865,
+                  51.483073061902296
+                ],
+                [
+                  -0.0752253103701215,
+                  51.483138902119634
+                ],
+                [
+                  -0.07493734998485325,
+                  51.483240708662436
+                ],
+                [
+                  -0.07468573980210308,
+                  51.48337476468626
+                ],
+                [
+                  -0.07447966625880034,
+                  51.483536175916264
+                ],
+                [
+                  -0.07432665351938529,
+                  51.483719049304945
+                ],
+                [
+                  -0.0742322887326799,
+                  51.48391670815698
+                ],
+                [
+                  -0.07415527994534045,
+                  51.484161707043235
+                ],
+                [
+                  -0.07412307707964114,
+                  51.484378824770474
+                ],
+                [
+                  -0.07416161468926359,
+                  51.48459554194685
+                ],
+                [
+                  -0.07426932058476096,
+                  51.484803011794625
+                ],
+                [
+                  -0.07444179886249265,
+                  51.48499276491181
+                ],
+                [
+                  -0.074672009221287,
+                  51.48515705503473
+                ],
+                [
+                  -0.07495055427489787,
+                  51.485289175294774
+                ],
+                [
+                  -0.0752660631451402,
+                  51.485383732052064
+                ],
+                [
+                  -0.07560565568040607,
+                  51.48543686512013
+                ],
+                [
+                  -0.07563865643674306,
+                  51.48543986519039
+                ],
+                [
+                  -0.07597871334451682,
+                  51.485449737443865
+                ],
+                [
+                  -0.07606783741935134,
+                  51.48544134015071
+                ],
+                [
+                  -0.07610903686861933,
+                  51.48544811115062
+                ],
+                [
+                  -0.07636504268921902,
+                  51.48547411175793
+                ],
+                [
+                  -0.07670939164615519,
+                  51.48548741590888
+                ],
+                [
+                  -0.07705114879260505,
+                  51.48545797882999
+                ],
+                [
+                  -0.07737676854911488,
+                  51.48538696726444
+                ],
+                [
+                  -0.0776733450725096,
+                  51.48527719575741
+                ],
+                [
+                  -0.07792912386259696,
+                  51.48513301507986
+                ],
+                [
+                  -0.0781339676929286,
+                  51.48496013975597
+                ],
+                [
+                  -0.0782797583884334,
+                  51.48476542153637
+                ],
+                [
+                  -0.07836071852417716,
+                  51.48455657780224
+                ],
+                [
+                  -0.07840771069514788,
+                  51.48434457711614
+                ]
+              ]
+            ]
+          }
+        },
+        "proposal.site.area": 1232.22,
+        "proposal.site.hectares": 0.123222,
+        "drawBoundary.action": "Accepted the title boundary"
+      }
+    },
+    "M25kTJaupX": {
+      "auto": true,
+      "data": {
+        "proposal.site.area.half": 616.11
+      }
+    },
+    "594ajFBA8C": {
+      "auto": true,
+      "data": {
+        "proposal.site.area.hectares.double": 0.246444
+      }
+    },
+    "XDlfXlSFJY": {
+      "auto": false,
+      "data": {
+        "_constraints": [
+          {
+            "sourceRequest": "https://www.planning.data.gov.uk/entity.json?entries=current&geometry=MULTIPOLYGON+%28%28%28-0.076691+51.484197%2C+-0.075933+51.484124%2C+-0.075856+51.484369%2C+-0.075889+51.484372%2C+-0.0759+51.484324%2C+-0.076391+51.484369%2C+-0.076388+51.484383%2C+-0.076644+51.484409%2C+-0.076691+51.484197%29%29%29&geometry_relation=intersects&exclude_field=geometry%2Cpoint&limit=100&dataset=article-4-direction-area&dataset=central-activities-zone&dataset=brownfield-land&dataset=brownfield-site&dataset=area-of-outstanding-natural-beauty&dataset=conservation-area&dataset=green-belt&dataset=national-park&dataset=world-heritage-site&dataset=world-heritage-site-buffer-zone&dataset=flood-risk-zone&dataset=listed-building&dataset=listed-building-outline&dataset=scheduled-monument&dataset=ancient-woodland&dataset=ramsar&dataset=special-area-of-conservation&dataset=special-protection-area&dataset=site-of-special-scientific-interest&dataset=park-and-garden&dataset=tree&dataset=tree-preservation-order&dataset=tree-preservation-zone",
+            "constraints": {
+              "listed": {
+                "fn": "listed",
+                "value": true,
+                "text": "is, or is within, a Listed Building",
+                "data": [
+                  {
+                    "entry-date": "2023-08-16",
+                    "start-date": "1954-06-30",
+                    "end-date": "",
+                    "entity": 42115431,
+                    "name": "New Peckham mosque (former church of St Mark)",
+                    "dataset": "listed-building-outline",
+                    "typology": "geography",
+                    "reference": "470793",
+                    "prefix": "listed-building-outline",
+                    "organisation-entity": "329",
+                    "document-url": "https://geomap.southwark.gov.uk/connect/analyst/Includes/ListedBuildings/SwarkLB205.pdf",
+                    "listed-building": "470793",
+                    "documentation-url": "https://geo.southwark.gov.uk/connect/analyst/Includes/ListedBuildings/SwarkLB205.pdf"
+                  }
+                ],
+                "category": "Heritage and conservation"
+              },
+              "designated.conservationArea": {
+                "fn": "designated.conservationArea",
+                "value": true,
+                "text": "is in a Conservation Area",
+                "data": [
+                  {
+                    "entry-date": "2024-07-11",
+                    "start-date": "1980-02-05",
+                    "end-date": "",
+                    "entity": 44010233,
+                    "name": "Cobourg Road",
+                    "dataset": "conservation-area",
+                    "typology": "geography",
+                    "reference": "19",
+                    "prefix": "conservation-area",
+                    "organisation-entity": "329",
+                    "document-url": "https://www.southwark.gov.uk/planning-and-building-control/design-and-conservation/conservation-areas?chapter=10",
+                    "designation-date": "1980-02-05",
+                    "documentation-url": "https://www.southwark.gov.uk/planning-and-building-control/design-and-conservation/conservation-areas?chapter=10"
+                  }
+                ],
+                "category": "Heritage and conservation"
+              },
+              "flood": {
+                "fn": "flood",
+                "value": true,
+                "text": "is in a Flood Risk Zone",
+                "data": [
+                  {
+                    "entry-date": "2023-08-24",
+                    "start-date": "",
+                    "end-date": "",
+                    "entity": 65106806,
+                    "name": "",
+                    "dataset": "flood-risk-zone",
+                    "typology": "geography",
+                    "reference": "106807",
+                    "prefix": "flood-risk-zone",
+                    "organisation-entity": "600009",
+                    "flood-risk-type": "Tidal Models",
+                    "flood-risk-level": "3"
+                  },
+                  {
+                    "entry-date": "2023-08-24",
+                    "start-date": "",
+                    "end-date": "",
+                    "entity": 65232137,
+                    "name": "",
+                    "dataset": "flood-risk-zone",
+                    "typology": "geography",
+                    "reference": "232138",
+                    "prefix": "flood-risk-zone",
+                    "organisation-entity": "600009",
+                    "flood-risk-type": "Tidal Models",
+                    "flood-risk-level": "2"
+                  }
+                ],
+                "category": "Flooding"
+              },
+              "tpo": {
+                "fn": "tpo",
+                "value": true,
+                "text": "is in a Tree Preservation Order (TPO) Zone",
+                "data": [
+                  {
+                    "entry-date": "2021-02-02",
+                    "start-date": "2021-02-02",
+                    "end-date": "",
+                    "entity": 7002050495,
+                    "name": "103 Coburg Road, SE5 0HU",
+                    "dataset": "tree",
+                    "typology": "geography",
+                    "reference": "537",
+                    "prefix": "tree",
+                    "organisation-entity": "329",
+                    "tree-preservation-order": "606",
+                    "tree-preservation-order-tree": "Individual"
+                  }
+                ],
+                "category": "Trees"
+              },
+              "articleFour": {
+                "fn": "articleFour",
+                "value": false,
+                "text": "is not in an Article 4 direction area",
+                "category": "General policy"
+              },
+              "articleFour.caz": {
+                "fn": "articleFour.caz",
+                "value": false,
+                "text": "is not in the Central Activities Zone",
+                "category": "General policy"
+              },
+              "brownfieldSite": {
+                "fn": "brownfieldSite",
+                "value": false,
+                "text": "is not on Brownfield land",
+                "category": "General policy"
+              },
+              "designated.AONB": {
+                "fn": "designated.AONB",
+                "value": false,
+                "text": "is not in an Area of Outstanding Natural Beauty",
+                "category": "Heritage and conservation"
+              },
+              "greenBelt": {
+                "fn": "greenBelt",
+                "value": false,
+                "text": "is not in a Green Belt",
+                "category": "General policy"
+              },
+              "designated.nationalPark": {
+                "fn": "designated.nationalPark",
+                "value": false,
+                "text": "is not in a National Park",
+                "category": "Heritage and conservation"
+              },
+              "designated.nationalPark.broads": {
+                "fn": "designated.nationalPark.broads",
+                "value": false
+              },
+              "designated.WHS": {
+                "fn": "designated.WHS",
+                "value": false,
+                "text": "is not an UNESCO World Heritage Site",
+                "category": "Heritage and conservation"
+              },
+              "monument": {
+                "fn": "monument",
+                "value": false,
+                "text": "is not the site of a Scheduled Monument",
+                "category": "Heritage and conservation"
+              },
+              "nature.ASNW": {
+                "fn": "nature.ASNW",
+                "value": false,
+                "text": "is not in an Ancient Semi-Natural Woodland (ASNW)",
+                "category": "Ecology"
+              },
+              "nature.ramsarSite": {
+                "fn": "nature.ramsarSite",
+                "value": false,
+                "text": "is not in a Ramsar Site",
+                "category": "Ecology"
+              },
+              "nature.SAC": {
+                "fn": "nature.SAC",
+                "value": false,
+                "text": "is not in a Special Area of Conservation (SAC)",
+                "category": "Ecology"
+              },
+              "nature.SPA": {
+                "fn": "nature.SPA",
+                "value": false,
+                "text": "is not in a Special Protection Area (SPA)",
+                "category": "Ecology"
+              },
+              "nature.SSSI": {
+                "fn": "nature.SSSI",
+                "value": false,
+                "text": "is not a Site of Special Scientific Interest (SSSI)",
+                "category": "Ecology"
+              },
+              "registeredPark": {
+                "fn": "registeredPark",
+                "value": false,
+                "text": "is not in a Historic Park or Garden",
+                "category": "Heritage and conservation"
+              },
+              "designated": {
+                "value": true
+              },
+              "flood.zoneTwo": {
+                "fn": "flood.zoneTwo",
+                "value": true
+              },
+              "flood.zoneThree": {
+                "fn": "flood.zoneThree",
+                "value": true
+              },
+              "listed.gradeOne": {
+                "fn": "listed.gradeOne",
+                "value": false
+              },
+              "listed.gradeTwo": {
+                "fn": "listed.gradeTwo",
+                "value": false
+              },
+              "listed.gradeTwoStar": {
+                "fn": "listed.gradeTwoStar",
+                "value": false
+              }
+            },
+            "metadata": {
+              "articleFour": {
+                "entry-date": "",
+                "start-date": "",
+                "end-date": "",
+                "collection": "article-4-direction",
+                "dataset": "article-4-direction-area",
+                "description": "Orders made by the local planning authority to remove all or some of the permitted development rights on a site in order to protect it",
+                "name": "Article 4 direction area",
+                "plural": "Article 4 direction areas",
+                "prefix": "",
+                "text": "A local planning authority may create an [article 4 direction](https://www.gov.uk/guidance/when-is-permission-required#article-4-direction) to alter or remove [permitted development rights](https://www.gov.uk/government/publications/permitted-development-rights-for-householders-technical-guidance) from a building or area.\n\nEach [article 4 direction](/dataset/article-4-direction) may apply to one or more article 4 direction areas.",
+                "typology": "geography",
+                "wikidata": "",
+                "wikipedia": "",
+                "entities": "",
+                "themes": [
+                  "heritage"
+                ],
+                "entity-count": {
+                  "dataset": "article-4-direction-area",
+                  "count": 2757
+                },
+                "paint-options": "",
+                "attribution": "crown-copyright",
+                "attribution-text": "© Crown copyright and database right 2025",
+                "licence": "ogl3",
+                "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+                "consideration": "article-4-directions",
+                "github-discussion": 30,
+                "entity-minimum": 7010000000,
+                "entity-maximum": 7019999999,
+                "phase": "beta",
+                "realm": "dataset",
+                "replacement-dataset": "",
+                "version": "3.0"
+              },
+              "articleFour.caz": {
+                "entry-date": "",
+                "start-date": "",
+                "end-date": "",
+                "collection": "central-activities-zone",
+                "dataset": "central-activities-zone",
+                "description": "",
+                "name": "Central activities zone",
+                "plural": "Central activities zones",
+                "prefix": "",
+                "text": "The [Greater London Authority](https://www.london.gov.uk/) (GLA) designates a central area of London with [implications for planning](https://www.london.gov.uk/what-we-do/planning/implementing-london-plan/london-plan-guidance-and-spgs/central-activities-zone)\nThis dataset combines data provided by the GLA with the boundary from the individual London boroughs.",
+                "typology": "geography",
+                "wikidata": "",
+                "wikipedia": "",
+                "entities": "",
+                "themes": [
+                  "development"
+                ],
+                "entity-count": {
+                  "dataset": "central-activities-zone",
+                  "count": 10
+                },
+                "paint-options": "",
+                "attribution": "crown-copyright",
+                "attribution-text": "© Crown copyright and database right 2025",
+                "licence": "ogl3",
+                "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+                "consideration": "central-activty-zones",
+                "github-discussion": "",
+                "entity-minimum": 2200000,
+                "entity-maximum": 2299999,
+                "phase": "beta",
+                "realm": "dataset",
+                "replacement-dataset": "",
+                "version": "1.0"
+              },
+              "brownfieldSite": {
+                "entry-date": "",
+                "start-date": "",
+                "end-date": "",
+                "collection": "brownfield-site",
+                "dataset": "brownfield-site",
+                "description": "",
+                "name": "Brownfield site",
+                "plural": "Brownfield sites",
+                "prefix": "",
+                "text": "This is an experimental dataset of the boundaries of brownfield sites found on [data.gov.uk](https://www.data.gov.uk/search?q=brownfield)\nand local planning authority web sites.\nWe expect to combine this dataset with the [brownfield land](/dataset/brownfield-land) dataset in the near future.",
+                "typology": "geography",
+                "wikidata": "Q896586",
+                "wikipedia": "Brownfield_land",
+                "entities": "",
+                "themes": [
+                  "development"
+                ],
+                "entity-count": {
+                  "dataset": "brownfield-site",
+                  "count": 2852
+                },
+                "paint-options": {
+                  "colour": "#745729"
+                },
+                "attribution": "crown-copyright",
+                "attribution-text": "© Crown copyright and database right 2025",
+                "licence": "ogl3",
+                "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+                "consideration": "brownfield-land",
+                "github-discussion": 28,
+                "entity-minimum": 1800000,
+                "entity-maximum": 1899999,
+                "phase": "alpha",
+                "realm": "dataset",
+                "replacement-dataset": "",
+                "version": "1.0"
+              },
+              "designated.AONB": {
+                "entry-date": "",
+                "start-date": "",
+                "end-date": "",
+                "collection": "area-of-outstanding-natural-beauty",
+                "dataset": "area-of-outstanding-natural-beauty",
+                "description": "Land protected by law to conserve and enhance its natural beauty",
+                "name": "Area of outstanding natural beauty",
+                "plural": "Areas of outstanding natural beauty",
+                "prefix": "",
+                "text": "An area of outstanding natural beauty (AONB) as designated by [Natural England](https://www.gov.uk/government/organisations/natural-england).\n\nNatural England provides [guidance](https://www.gov.uk/guidance/protected-sites-and-areas-how-to-review-planning-applications) to help local authorities decide on planning applications in protected sites and areas.",
+                "typology": "geography",
+                "wikidata": "Q174945",
+                "wikipedia": "Area_of_Outstanding_Natural_Beauty",
+                "entities": "",
+                "themes": [
+                  "environment"
+                ],
+                "entity-count": {
+                  "dataset": "area-of-outstanding-natural-beauty",
+                  "count": 34
+                },
+                "paint-options": {
+                  "colour": "#d53880"
+                },
+                "attribution": "natural-england",
+                "attribution-text": "© Natural England copyright. Contains Ordnance Survey data © Crown copyright and database right 2025.",
+                "licence": "ogl3",
+                "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+                "consideration": "areas-of-outstanding-natural-beauty",
+                "github-discussion": 31,
+                "entity-minimum": 1000000,
+                "entity-maximum": 1099999,
+                "phase": "live",
+                "realm": "dataset",
+                "replacement-dataset": "",
+                "version": "1.0"
+              },
+              "designated.conservationArea": {
+                "entry-date": "",
+                "start-date": "",
+                "end-date": "",
+                "collection": "conservation-area",
+                "dataset": "conservation-area",
+                "description": "Special architectural or historic interest, the character or appearance of which it is desirable to preserve or enhance",
+                "name": "Conservation area",
+                "plural": "Conservation areas",
+                "prefix": "",
+                "text": "Local planning authorities are responsible for designating conservation areas, though [Historic England](https://historicengland.org.uk/) and the Secretary of State also have powers to create them.\n\nThis dataset also contains the boundaries of conservation areas from Historic England, as well as other data found on [data.gov.uk](https://www.data.gov.uk/search?q=conservation+area) and currently contains a number of duplicate areas we are working to remove.\n\nWe are also [working with a group of local planning authorities](/about/) to help them publish their conservation areas, and to develop a [data specification for conservation areas](https://www.digital-land.info/guidance/specifications/conservation-area).\n\nHistoric England provide [guidance](https://historicengland.org.uk/advice/your-home/owning-historic-property/conservation-area/) to help householders understand the implications of living in a conservation area for planning applications.",
+                "typology": "geography",
+                "wikidata": "Q5162904",
+                "wikipedia": "Conservation_area_(United_Kingdom)",
+                "entities": "",
+                "themes": [
+                  "heritage"
+                ],
+                "entity-count": {
+                  "dataset": "conservation-area",
+                  "count": 11167
+                },
+                "paint-options": {
+                  "colour": "#78AA00"
+                },
+                "attribution": "historic-england",
+                "attribution-text": "© Historic England 2025. Contains Ordnance Survey data © Crown copyright and database right 2025.\nThe Historic England GIS Data contained in this material was obtained on [date].\nThe most publicly available up to date Historic England GIS Data can be obtained from [HistoricEngland.org.uk](https://historicengland.org.uk).",
+                "licence": "ogl3",
+                "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+                "consideration": "conservation-areas",
+                "github-discussion": 33,
+                "entity-minimum": 44000000,
+                "entity-maximum": 44999999,
+                "phase": "beta",
+                "realm": "dataset",
+                "replacement-dataset": "",
+                "version": "3.0"
+              },
+              "greenBelt": {
+                "entry-date": "",
+                "start-date": "",
+                "end-date": "",
+                "collection": "green-belt",
+                "dataset": "green-belt",
+                "description": "",
+                "name": "Green belt",
+                "plural": "Green belt",
+                "prefix": "",
+                "text": "Boundaries for land designated by a local planning authority as being [green belt](https://www.gov.uk/guidance/green-belt),\ngrouped using the [greenbelt core](/dataset/greenbelt-core) category.\nThis data is compiled by the Department for Levelling Up, Housing and Communities for the purposes of gathering [green belt statistics](https://www.gov.uk/government/collections/green-belt-statistics).",
+                "typology": "geography",
+                "wikidata": "Q2734873",
+                "wikipedia": "Green_belt_(United_Kingdom)",
+                "entities": "",
+                "themes": [
+                  "environment"
+                ],
+                "entity-count": {
+                  "dataset": "green-belt",
+                  "count": 185
+                },
+                "paint-options": {
+                  "colour": "#85994b"
+                },
+                "attribution": "os-open-data",
+                "attribution-text": "Your use of OS OpenData is subject to the terms at http://os.uk/opendata/licence\nContains Ordnance Survey data © Crown copyright and database right 2025",
+                "licence": "ogl3",
+                "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+                "consideration": "greenbelt",
+                "github-discussion": 45,
+                "entity-minimum": 610000,
+                "entity-maximum": 610999,
+                "phase": "beta",
+                "realm": "dataset",
+                "replacement-dataset": "",
+                "version": "1.0"
+              },
+              "designated.nationalPark": {
+                "entry-date": "",
+                "start-date": "",
+                "end-date": "",
+                "collection": "national-park",
+                "dataset": "national-park",
+                "description": "",
+                "name": "National park",
+                "plural": "National parks",
+                "prefix": "statistical-geography",
+                "text": "The administrative boundaries of [national park authorities](/dataset/national-park-authority) in England as provided by the ONS for the purposes of producing statistics.",
+                "typology": "geography",
+                "wikidata": "Q60256727",
+                "wikipedia": "National_park",
+                "entities": "",
+                "themes": [
+                  "heritage"
+                ],
+                "entity-count": {
+                  "dataset": "national-park",
+                  "count": 10
+                },
+                "paint-options": {
+                  "colour": "#3DA52C"
+                },
+                "attribution": "ons-boundary",
+                "attribution-text": "Source: Office for National Statistics licensed under the Open Government Licence v.3.0\nContains OS data © Crown copyright and database right 2025",
+                "licence": "ogl3",
+                "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+                "consideration": "national-parks-and-the-broads",
+                "github-discussion": "",
+                "entity-minimum": 520000,
+                "entity-maximum": 520999,
+                "phase": "beta",
+                "realm": "dataset",
+                "replacement-dataset": "",
+                "version": "1.0"
+              },
+              "designated.WHS": {
+                "entry-date": "",
+                "start-date": "",
+                "end-date": "",
+                "collection": "historic-england",
+                "dataset": "world-heritage-site-buffer-zone",
+                "description": "",
+                "name": "World heritage site buffer zone",
+                "plural": "World heritage site buffer zones",
+                "prefix": "",
+                "text": "A [World Heritage Site](/dataset/world-heritage-site) may have a [buffer zone](https://whc.unesco.org/en/series/25/) with implications for planning.",
+                "typology": "geography",
+                "wikidata": "Q9259",
+                "wikipedia": "World_Heritage_Site",
+                "entities": "",
+                "themes": [
+                  "heritage"
+                ],
+                "entity-count": {
+                  "dataset": "world-heritage-site-buffer-zone",
+                  "count": 9
+                },
+                "paint-options": {
+                  "colour": "#EB1EE5",
+                  "opacity": 0.2
+                },
+                "attribution": "historic-england",
+                "attribution-text": "© Historic England 2025. Contains Ordnance Survey data © Crown copyright and database right 2025.\nThe Historic England GIS Data contained in this material was obtained on [date].\nThe most publicly available up to date Historic England GIS Data can be obtained from [HistoricEngland.org.uk](https://historicengland.org.uk).",
+                "licence": "ogl3",
+                "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+                "consideration": "world-heritage-sites",
+                "github-discussion": "",
+                "entity-minimum": 16110000,
+                "entity-maximum": 16129999,
+                "phase": "beta",
+                "realm": "dataset",
+                "replacement-dataset": "",
+                "version": "1.0"
+              },
+              "flood": {
+                "entry-date": "",
+                "start-date": "",
+                "end-date": "",
+                "collection": "flood-risk-zone",
+                "dataset": "flood-risk-zone",
+                "description": "Area identified as being at risk of flooding from rivers or the sea",
+                "name": "Flood risk zone",
+                "plural": "Flood risk zones",
+                "prefix": "",
+                "text": "Flood zones are a guide produced by the Environment Agency to demonstrate the probability of river and sea flooding in areas across England. Flood zones are based on the likelihood of an area flooding, with flood zone 1 areas least likely to flood and flood zone 3 areas more likely to flood. \n\nThe flood zones were produced to help developers, councils and communities understand the flood risks present in specific locations or regions. Despite being a very useful indicator of an area’s flood risk, the zones cannot tell you whether a location will definitely flood or to what severity.",
+                "typology": "geography",
+                "wikidata": "",
+                "wikipedia": "",
+                "entities": "",
+                "themes": [
+                  "environment"
+                ],
+                "entity-count": {
+                  "dataset": "flood-risk-zone",
+                  "count": 550621
+                },
+                "paint-options": "",
+                "attribution": "crown-copyright",
+                "attribution-text": "© Crown copyright and database right 2025",
+                "licence": "ogl3",
+                "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+                "consideration": "flood-risk-zones",
+                "github-discussion": 46,
+                "entity-minimum": 65000000,
+                "entity-maximum": 65999999,
+                "phase": "live",
+                "realm": "dataset",
+                "replacement-dataset": "",
+                "version": "1.0"
+              },
+              "listed": {
+                "entry-date": "",
+                "start-date": "",
+                "end-date": "",
+                "collection": "listed-building",
+                "dataset": "listed-building-outline",
+                "description": "boundary of a listed building",
+                "name": "Listed building outline",
+                "plural": "Listed building outlines",
+                "prefix": "",
+                "text": "The geospatial boundary for [listed buildings](https://historicengland.org.uk/listing/what-is-designation/listed-buildings) as designated by [Historic England](https://historicengland.org.uk/) as collected from local planning authorities.\n\nWe are [working with a group of local planning authorities](/about/) to help them publish their data to inform planning decisions, and to develop a [data specification for listed building outlines](https://www.digital-land.info/guidance/specifications/listed-building).\n\nWe expect to eventually merge this dataset with the [listed building](/dataset/listed-building) dataset.",
+                "typology": "geography",
+                "wikidata": "Q570600",
+                "wikipedia": "Listed_building",
+                "entities": "",
+                "themes": [
+                  "heritage"
+                ],
+                "entity-count": {
+                  "dataset": "listed-building-outline",
+                  "count": 37369
+                },
+                "paint-options": {
+                  "colour": "#F9C744"
+                },
+                "attribution": "crown-copyright",
+                "attribution-text": "© Crown copyright and database right 2025",
+                "licence": "ogl3",
+                "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+                "consideration": "listed-buildings",
+                "github-discussion": 44,
+                "entity-minimum": 42100000,
+                "entity-maximum": 43099999,
+                "phase": "alpha",
+                "realm": "dataset",
+                "replacement-dataset": "",
+                "version": "1.0"
+              },
+              "monument": {
+                "entry-date": "",
+                "start-date": "",
+                "end-date": "",
+                "collection": "historic-england",
+                "dataset": "scheduled-monument",
+                "description": "",
+                "name": "Scheduled monument",
+                "plural": "Scheduled monuments",
+                "prefix": "",
+                "text": "Historic buildings or sites such as Roman remains, burial mounds, castles, bridges, earthworks, the remains of deserted villages and industrial sites can be designated scheduled monuments by the Secretary of State for [Digital, Culture, Media and Sport](https://www.gov.uk/government/organisations/department-for-digital-culture-media-sport). \n\nThis list of scheduled monuments is kept and maintained by [Historic England](https://historicengland.org.uk/).",
+                "typology": "geography",
+                "wikidata": "Q219538",
+                "wikipedia": "Scheduled_monument",
+                "entities": "",
+                "themes": [
+                  "heritage"
+                ],
+                "entity-count": {
+                  "dataset": "scheduled-monument",
+                  "count": 19999
+                },
+                "paint-options": {
+                  "colour": "#0F9CDA"
+                },
+                "attribution": "historic-england",
+                "attribution-text": "© Historic England 2025. Contains Ordnance Survey data © Crown copyright and database right 2025.\nThe Historic England GIS Data contained in this material was obtained on [date].\nThe most publicly available up to date Historic England GIS Data can be obtained from [HistoricEngland.org.uk](https://historicengland.org.uk).",
+                "licence": "ogl3",
+                "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+                "consideration": "scheduled-monuments",
+                "github-discussion": "",
+                "entity-minimum": 13900000,
+                "entity-maximum": 13999999,
+                "phase": "beta",
+                "realm": "dataset",
+                "replacement-dataset": "",
+                "version": "1.0"
+              },
+              "nature.ASNW": {
+                "entry-date": "",
+                "start-date": "",
+                "end-date": "",
+                "collection": "ancient-woodland",
+                "dataset": "ancient-woodland",
+                "description": "An area that’s been wooded continuously since at least 1600 AD",
+                "name": "Ancient woodland",
+                "plural": "Ancient woodlands",
+                "prefix": "",
+                "text": "An area designated as ancient woodland by Natural England.\n\nNatural England and Forestry Commission [Guidance](https://www.gov.uk/guidance/ancient-woodland-and-veteran-trees-protection-surveys-licences)  is used in planning decisions.",
+                "typology": "geography",
+                "wikidata": "Q3078732",
+                "wikipedia": "Ancient_woodland",
+                "entities": "",
+                "themes": [
+                  "environment"
+                ],
+                "entity-count": {
+                  "dataset": "ancient-woodland",
+                  "count": 44373
+                },
+                "paint-options": {
+                  "colour": "#00703c",
+                  "opacity": 0.2
+                },
+                "attribution": "natural-england",
+                "attribution-text": "© Natural England copyright. Contains Ordnance Survey data © Crown copyright and database right 2025.",
+                "licence": "ogl3",
+                "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+                "consideration": "ancient-woodlands",
+                "github-discussion": 32,
+                "entity-minimum": 110000000,
+                "entity-maximum": 129999999,
+                "phase": "live",
+                "realm": "dataset",
+                "replacement-dataset": "",
+                "version": "1.0"
+              },
+              "nature.ramsarSite": {
+                "entry-date": "",
+                "start-date": "",
+                "end-date": "",
+                "collection": "ramsar",
+                "dataset": "ramsar",
+                "description": "",
+                "name": "Ramsar site",
+                "plural": "Ramsar sites",
+                "prefix": "",
+                "text": "An internationally protected site listed as a wetland of international importance.\nRamsar sites are designated by [UNESCO](https://en.unesco.org/) and managed by [Natural England](https://www.gov.uk/government/organisations/natural-england).\n\nNatural England provides [guidance ](https://www.gov.uk/guidance/protected-sites-and-areas-how-to-review-planning-applications) to help local authorities decide on planning applications in protected sites and areas.",
+                "typology": "geography",
+                "wikidata": "",
+                "wikipedia": "",
+                "entities": "",
+                "themes": [
+                  "environment"
+                ],
+                "entity-count": {
+                  "dataset": "ramsar",
+                  "count": 73
+                },
+                "paint-options": {
+                  "colour": "#7fcdff"
+                },
+                "attribution": "natural-england",
+                "attribution-text": "© Natural England copyright. Contains Ordnance Survey data © Crown copyright and database right 2025.",
+                "licence": "ogl3",
+                "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+                "consideration": "ramsar",
+                "github-discussion": 41,
+                "entity-minimum": 612000,
+                "entity-maximum": 619999,
+                "phase": "beta",
+                "realm": "dataset",
+                "replacement-dataset": "",
+                "version": "1.0"
+              },
+              "nature.SAC": {
+                "entry-date": "",
+                "start-date": "",
+                "end-date": "",
+                "collection": "special-area-of-conservation",
+                "dataset": "special-area-of-conservation",
+                "description": "",
+                "name": "Special area of conservation",
+                "plural": "Special areas of conservation",
+                "prefix": "",
+                "text": "Special areas of conservation (SACs) are area of land which have been designated by\n[DEFRA](https://www.gov.uk/government/organisations/department-for-environment-food-rural-affairs),\nwith advice from the [Joint Nature Conservation Committee](https://jncc.gov.uk/),\nto protect specific habitats and species.\n\nDEFRA and [Natural England](https://www.gov.uk/government/organisations/natural-england) publish\n[guidance](https://www.gov.uk/guidance/protected-sites-and-areas-how-to-review-planning-applications)\non how to review planning applications in protected sites and areas.",
+                "typology": "geography",
+                "wikidata": "Q1191622",
+                "wikipedia": "Special_Area_of_Conservation",
+                "entities": "",
+                "themes": [
+                  "environment"
+                ],
+                "entity-count": {
+                  "dataset": "special-area-of-conservation",
+                  "count": 260
+                },
+                "paint-options": {
+                  "colour": "#7A8705"
+                },
+                "attribution": "natural-england",
+                "attribution-text": "© Natural England copyright. Contains Ordnance Survey data © Crown copyright and database right 2025.",
+                "licence": "ogl3",
+                "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+                "consideration": "special-areas-of-conservation",
+                "github-discussion": "",
+                "entity-minimum": 14800000,
+                "entity-maximum": 14899999,
+                "phase": "beta",
+                "realm": "dataset",
+                "replacement-dataset": "",
+                "version": "1.0"
+              },
+              "nature.SPA": {
+                "entry-date": "",
+                "start-date": "",
+                "end-date": "",
+                "collection": "special-protection-area",
+                "dataset": "special-protection-area",
+                "description": "",
+                "name": "Special protection area",
+                "plural": "Special protection areas",
+                "prefix": "",
+                "text": "[Special protection areas](https://naturalengland-defra.opendata.arcgis.com/maps/Defra::special-protection-areas-england/about) is an area designated \nfor the protection of birds and wildlife. This dataset is provided by [Natural England](https://www.gov.uk/government/organisations/natural-england).",
+                "typology": "geography",
+                "wikidata": "",
+                "wikipedia": "",
+                "entities": "",
+                "themes": [
+                  "environment"
+                ],
+                "entity-count": {
+                  "dataset": "special-protection-area",
+                  "count": 88
+                },
+                "paint-options": "",
+                "attribution": "natural-england",
+                "attribution-text": "© Natural England copyright. Contains Ordnance Survey data © Crown copyright and database right 2025.",
+                "licence": "ogl3",
+                "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+                "consideration": "special-protection-areas",
+                "github-discussion": "",
+                "entity-minimum": 14900000,
+                "entity-maximum": 14999999,
+                "phase": "beta",
+                "realm": "dataset",
+                "replacement-dataset": "",
+                "version": "1.0"
+              },
+              "nature.SSSI": {
+                "entry-date": "",
+                "start-date": "",
+                "end-date": "",
+                "collection": "site-of-special-scientific-interest",
+                "dataset": "site-of-special-scientific-interest",
+                "description": "",
+                "name": "Site of special scientific interest",
+                "plural": "Sites of special scientific interest",
+                "prefix": "",
+                "text": "Sites of special scientific interest (SSSI) are nationally protected sites that have features such as wildlife or geology. \n\nSSSIs are designated by [Natural England](https://www.gov.uk/government/organisations/natural-england).\nThere is [guidance](https://www.gov.uk/guidance/protected-areas-sites-of-special-scientific-interest) to help local authorities decide on planning applications in protected SSSIs.",
+                "typology": "geography",
+                "wikidata": "Q422211",
+                "wikipedia": "Site_of_Special_Scientific_Interest",
+                "entities": "",
+                "themes": [
+                  "environment"
+                ],
+                "entity-count": {
+                  "dataset": "site-of-special-scientific-interest",
+                  "count": 4129
+                },
+                "paint-options": {
+                  "colour": "#308fac"
+                },
+                "attribution": "natural-england",
+                "attribution-text": "© Natural England copyright. Contains Ordnance Survey data © Crown copyright and database right 2025.",
+                "licence": "ogl3",
+                "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+                "consideration": "sites-of-special-scientific-interest",
+                "github-discussion": "",
+                "entity-minimum": 14500000,
+                "entity-maximum": 14599999,
+                "phase": "beta",
+                "realm": "dataset",
+                "replacement-dataset": "",
+                "version": "1.0"
+              },
+              "registeredPark": {
+                "entry-date": "",
+                "start-date": "",
+                "end-date": "",
+                "collection": "historic-england",
+                "dataset": "park-and-garden",
+                "description": "",
+                "name": "Historic parks and gardens",
+                "plural": "Parks and gardens",
+                "prefix": "",
+                "text": "Historic parks and gardens as listed by [Historic England](https://historicengland.org.uk/) in the [Register of Parks and Gardens of Special Historic Interest](https://historicengland.org.uk/listing/what-is-designation/registered-parks-and-gardens/).",
+                "typology": "geography",
+                "wikidata": "Q6975250",
+                "wikipedia": "Register_of_Historic_Parks_and_Gardens_of_Special_Historic_Interest_in_England",
+                "entities": "",
+                "themes": [
+                  "environment",
+                  "heritage"
+                ],
+                "entity-count": {
+                  "dataset": "park-and-garden",
+                  "count": 1716
+                },
+                "paint-options": {
+                  "colour": "#0EB951"
+                },
+                "attribution": "historic-england",
+                "attribution-text": "© Historic England 2025. Contains Ordnance Survey data © Crown copyright and database right 2025.\nThe Historic England GIS Data contained in this material was obtained on [date].\nThe most publicly available up to date Historic England GIS Data can be obtained from [HistoricEngland.org.uk](https://historicengland.org.uk).",
+                "licence": "ogl3",
+                "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+                "consideration": "",
+                "github-discussion": "",
+                "entity-minimum": 11100000,
+                "entity-maximum": 11199999,
+                "phase": "beta",
+                "realm": "dataset",
+                "replacement-dataset": "",
+                "version": "1.0"
+              },
+              "tpo": {
+                "entry-date": "",
+                "start-date": "",
+                "end-date": "",
+                "collection": "tree-preservation-order",
+                "dataset": "tree-preservation-zone",
+                "description": "An area covered by a tree preservation order",
+                "name": "Tree preservation zone",
+                "plural": "Trees preservation zones",
+                "prefix": "",
+                "text": "A Tree Preservation Order (TPO) can be placed on single trees, groups of trees and even whole woodlands. Tree Preservation Orders are made by local planning authorities following [guidance](https://www.gov.uk/guidance/tree-preservation-orders-and-trees-in-conservation-areas) provided by the [Ministry of Housing, Communities and Local Governments](https://www.gov.uk/government/organisations/ministry-of-housing-communities-local-government).\n\nEach [tree preservation order](/dataset/tree-preservation-order) may apply to a number of tree preservation order zones, and a number of individual [trees](/dataset/tree).\n\nThis dataset contains data from [a small group of local planning authorities](/about/) who we are working with to develop a [data specification for tree preservation orders](https://www.digital-land.info/guidance/specifications/tree-preservation-order).",
+                "typology": "geography",
+                "wikidata": "Q10884",
+                "wikipedia": "Tree",
+                "entities": "",
+                "themes": [
+                  "environment"
+                ],
+                "entity-count": {
+                  "dataset": "tree-preservation-zone",
+                  "count": 26713
+                },
+                "paint-options": "",
+                "attribution": "crown-copyright",
+                "attribution-text": "© Crown copyright and database right 2025",
+                "licence": "ogl3",
+                "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+                "consideration": "tree-preservation-orders",
+                "github-discussion": 43,
+                "entity-minimum": 19100000,
+                "entity-maximum": 29099999,
+                "phase": "beta",
+                "realm": "dataset",
+                "replacement-dataset": "",
+                "version": "2.0"
+              }
+            },
+            "planxRequest": "https://api.editor.planx.uk/gis/testing?geom=MULTIPOLYGON+%28%28%28-0.076691+51.484197%2C+-0.075933+51.484124%2C+-0.075856+51.484369%2C+-0.075889+51.484372%2C+-0.0759+51.484324%2C+-0.076391+51.484369%2C+-0.076388+51.484383%2C+-0.076644+51.484409%2C+-0.076691+51.484197%29%29%29&vals=article4%2Carticle4.caz%2CbrownfieldSite%2Cdesignated.AONB%2Cdesignated.conservationArea%2CgreenBelt%2Cdesignated.nationalPark%2Cdesignated.nationalPark.broads%2Cdesignated.WHS%2Cflood%2Clisted%2Cmonument%2Cnature.ASNW%2Cnature.ramsarSite%2Cnature.SAC%2Cnature.SPA%2Cnature.SSSI%2CregisteredPark%2Ctpo%2Croad.classified&analytics=false"
+          },
+          {
+            "sourceRequest": "https://api.os.uk/features/v1/wfs?service=WFS&request=GetFeature&version=2.0.0&typeNames=Highways_RoadLink&outputFormat=GEOJSON&srsName=urn%3Aogc%3Adef%3Acrs%3AEPSG%3A%3A4326&count=1&filter=%0A++++%3Cogc%3AFilter%3E%0A++++++%3Cogc%3APropertyIsLike+wildCard%3D%22%25%22+singleChar%3D%22%23%22+escapeChar%3D%22%21%22%3E%0A++++++++%3Cogc%3APropertyName%3EFormsPartOf%3C%2Fogc%3APropertyName%3E%0A++++++++%3Cogc%3ALiteral%3E%25Street%23usrn22500531%25%3C%2Fogc%3ALiteral%3E%0A++++++%3C%2Fogc%3APropertyIsLike%3E%0A++++%3C%2Fogc%3AFilter%3E%0A++&",
+            "metadata": {
+              "road.classified": {
+                "name": "Classified road",
+                "plural": "Classified roads",
+                "text": "This will effect your project if you are looking to add a dropped kerb. It may also impact some agricultural or forestry projects within 25 metres of a classified road."
+              }
+            },
+            "constraints": {
+              "road.classified": {
+                "fn": "road.classified",
+                "value": false,
+                "text": "is not on a Classified Road",
+                "category": "General policy"
+              }
+            },
+            "planxRequest": "https://api.editor.planx.uk/roads?usrn=22500531"
+          }
+        ],
+        "planningConstraints.action": "Accepted all planning constraints",
+        "_nots": {
+          "property.constraints.planning": [
+            "articleFour",
+            "articleFour.caz",
+            "articleFour.buckinghamshire.osTwoSixTwo",
+            "articleFour.gateshead.saltwell.dFour",
+            "articleFour.newcastle.saintPetersBasinThree",
+            "brownfieldSite",
+            "designated.AONB",
+            "greenBelt",
+            "designated.nationalPark",
+            "designated.nationalPark.broads",
+            "designated.WHS",
+            "monument",
+            "nature.ASNW",
+            "nature.ramsarSite",
+            "nature.SAC",
+            "nature.SPA",
+            "nature.SSSI",
+            "registeredPark",
+            "listed.gradeOne",
+            "listed.gradeTwo",
+            "listed.gradeTwoStar",
+            "road.classified"
+          ]
+        },
+        "property.constraints.planning": [
+          "listed",
+          "designated.conservationArea",
+          "flood",
+          "tpo",
+          "designated",
+          "flood.zoneTwo",
+          "flood.zoneThree"
+        ]
+      }
+    },
+    "0xIFi1ZhfZ": {
+      "auto": true,
+      "answers": [
+        "5NwXOe2kl6",
+        "1DMLC1ilHg",
+        "S50pYmgKlM"
+      ]
+    },
+    "jtVZ3Xa3DE": {
+      "auto": false,
+      "answers": [
+        "fR27RXqLNn"
+      ]
+    },
+    "wvRHLsZyyk": {
+      "auto": true,
+      "answers": [
+        "0FIHMM1vcO",
+        "x4Zma010vS"
+      ]
+    },
+    "vEr4UyFu4u": {
+      "auto": false,
+      "answers": [
+        "rQ3yeKMo3r"
+      ]
+    },
+    "Z9dOoU0dD1": {
+      "auto": true,
+      "answers": [
+        "6m7kgvL204"
+      ]
+    },
+    "MQzrk4KPRO": {
+      "auto": true,
+      "answers": [
+        "zHeTwH6CaY"
+      ]
+    }
+  },
+};
+
+module.exports = { expectedSession };

--- a/jan2025_revisedSessions/tests/mocks/oldFlow.js
+++ b/jan2025_revisedSessions/tests/mocks/oldFlow.js
@@ -1,0 +1,1706 @@
+const oldFlow = {
+    "_root": {
+        "edges": [
+            "N8T7u2fedh",
+            "496NokZZcC",
+            "PXI9SWUFSM",
+            "9YqHTuXVjs",
+            "M25kTJaupX",
+            "594ajFBA8C",
+            "XDlfXlSFJY",
+            "0xIFi1ZhfZ",
+            "vEr4UyFu4u",
+            "Z9dOoU0dD1",
+            "MQzrk4KPRO",
+            "Result1",
+            "Result2",
+        ]
+    },
+    "Result1": {
+        "data": {
+            "flagSet": "Planning permission",
+            "overrides": {
+                "IMMUNE": {
+                    "heading": "It looks like this project may not need planning permission. However, planning conditions are not included in this service at the moment so you should always check with the council before doing any work.",
+                    "description": "This project happened long enough ago that it may not need planning permission. However, planning conditions are not included in this service at the moment so you should always check with the council before doing any work. We recommend applying for a Lawful Development Certificate. This will give you legal confirmation that the project does not need planning permission."
+                },
+                "PP-NOTICE": {
+                    "heading": "You need to tell us about the changes ",
+                    "description": "It looks like this project may not need planning permission. However, you must tell us about the changes in writing before starting work. "
+                },
+                "MISSING_INFO": {
+                    "heading": "Missing information",
+                    "description": "We need some more information to find out whether your project needs planning permission."
+                },
+                "PRIOR_APPROVAL": {
+                    "heading": "It looks like this project needs Prior Approval",
+                    "description": "Prior Approval means you may need to apply for approval from your local planning authority that specific parts of the development are acceptable before you start work."
+                },
+                "NO_APP_REQUIRED": {
+                    "heading": "It looks like this project does not need planning permission. ",
+                    "description": "This project may fall under permitted development, and therefore may not need planning permission. However, planning conditions are not included in this service at the moment. We recommend applying for a Lawful Development Certificate. This will give you legal confirmation that the project does not need planning permission."
+                },
+                "PP-NOT_DEVELOPMENT": {
+                    "heading": "It looks like this project does not need planning permission",
+                    "description": "This project may fall outside the legal definition of development and may not need planning permission. You can check this by applying for a Lawful Development Certificate before starting work, as there may be other things we need to check. This will give you legal confirmation that the project does not need planning permission."
+                },
+                "PLANNING_PERMISSION_REQUIRED": {
+                    "heading": "It looks like this project needs planning permission",
+                    "description": "Based on the information you have provided, this project needs planning permission. Continue to find out how to apply."
+                }
+            }
+        },
+        "type": 3
+    },
+    "Result2": {
+        "type": 3,
+        "data": {
+            "flagSet": "Listed building consent",
+            "overrides": {
+                "LB-REQUIRED": {
+                    "heading": "Custom heading when LBC is required"
+                }
+            }
+        }
+    },
+    "02aNXeNi17": {
+        "data": {
+            "val": "land.amenity.surface.pavement",
+            "text": "Pavement"
+        },
+        "type": 200
+    },
+    "0FIHMM1vcO": {
+        "data": {
+            "val": "flood.zone.2",
+            "text": "Zone 2 (Medium)"
+        },
+        "type": 200
+    },
+    "0xIFi1ZhfZ": {
+        "data": {
+            "fn": "property.constraints.planning",
+            "tags": [],
+            "text": "Do any of these constraints apply to you?",
+            "allRequired": false,
+            "neverAutoAnswer": false
+        },
+        "type": 105,
+        "edges": [
+            "tUsd2VX0CE",
+            "5NwXOe2kl6",
+            "1DMLC1ilHg",
+            "S50pYmgKlM"
+        ]
+    },
+    "13AhIhkjNx": {
+        "data": {
+            "fn": "property.type",
+            "text": "What type of religious property is it?"
+        },
+        "type": 100,
+        "edges": [
+            "Hx11x57Zy8",
+            "PNoPwbkS2L",
+            "HaOcUgqqqP",
+            "F7lubrvq95",
+            "YSoz99VKge",
+            "oIqbT6ofX4",
+            "pk3SFkfK0r",
+            "XrXi3rlRSZ",
+            "eR4Uk4wds5",
+            "LZ5owtXc8R",
+            "wkNZj4EJuR",
+            "ok2w6dmuEw",
+            "GF2Ubxttu3"
+        ]
+    },
+    "1DMLC1ilHg": {
+        "data": {
+            "val": "listed",
+            "text": "Listed building",
+            "flags": [
+                "LB-DE_MINIMIS"
+            ]
+        },
+        "type": 200,
+        "edges": [
+            "jtVZ3Xa3DE"
+        ]
+    },
+    "1ElP19Mpqq": {
+        "data": {
+            "fn": "property.type",
+            "info": "<p>This information helps your planning officer understand the site and the impact of the project. The type of property might affect what information you need to submit with your application. </p>",
+            "text": "What type of industrial property is it?"
+        },
+        "type": 100,
+        "edges": [
+            "nAQtDxo6c4",
+            "GJZ7xULXqK",
+            "NWT3CsFSCz",
+            "xHPFIDDV1V",
+            "J4IXSAlPTw"
+        ]
+    },
+    "1nHpe53Ytm": {
+        "data": {
+            "val": "commercial.community",
+            "text": "Institutions and community buildings"
+        },
+        "type": 200,
+        "edges": [
+            "XTgtfwSuLQ"
+        ]
+    },
+    "2FoekDHPbA": {
+        "data": {
+            "val": "article4.camden.147kentishTown",
+            "text": "Camden A4"
+        },
+        "type": 200
+    },
+    "2MlqAY7JKX": {
+        "data": {
+            "val": "commercial.medical.dentist",
+            "text": "Dentist"
+        },
+        "type": 200
+    },
+    "2Z4Ah7QPvE": {
+        "data": {
+            "val": "residential.dwelling.flat",
+            "text": "Flat (or building containing flats)"
+        },
+        "type": 200
+    },
+    "3FiKmXz0Ct": {
+        "data": {
+            "val": "other.unsupported",
+            "text": "No, none of these"
+        },
+        "type": 200,
+        "edges": [
+            "hNvEwECRda"
+        ]
+    },
+    "3Pp2uvwRfG": {
+        "data": {
+            "val": "commercial.retail.fuel",
+            "text": "Fuel station"
+        },
+        "type": 200
+    },
+    "3TJYlfAUz6": {
+        "data": {
+            "val": "object.religious.building",
+            "text": "Place of worship"
+        },
+        "type": 200,
+        "edges": [
+            "13AhIhkjNx"
+        ]
+    },
+    "3lblfduLSS": {
+        "data": {
+            "fn": "property.type",
+            "val": "land",
+            "operation": "replace"
+        },
+        "type": 380
+    },
+    "3s74llQcam": {
+        "data": {
+            "val": "commercial.retail.drinking",
+            "text": "Public house, bar or nightclub"
+        },
+        "type": 200
+    },
+    "3uLzlsc0DS": {
+        "data": {
+            "val": "commercial.leisure.entertainment.theatre",
+            "text": "Theatre"
+        },
+        "type": 200
+    },
+    "3zhtpyYEE1": {
+        "data": {
+            "val": "article4.lambeth.HMO",
+            "text": "HMO"
+        },
+        "type": 200
+    },
+    "496NokZZcC": {
+        "type": 300,
+        "edges": [
+            "6689164d-2a5e-422f-8d6a-d3ea11a2fbb9"
+        ]
+    },
+    "4n7h4JzAJR": {
+        "data": {
+            "val": "commercial.retail.other",
+            "text": "Other"
+        },
+        "type": 200,
+        "edges": [
+            "UW5C3zLAVR"
+        ]
+    },
+    "4xoUWkORDG": {
+        "data": {
+            "val": "commercial.community.hall",
+            "text": "Community hall"
+        },
+        "type": 200
+    },
+    "594ajFBA8C": {
+        "data": {
+            "fn": "proposal.site.area.hectares.double",
+            "title": "Double the site boundary in hectares",
+            "formula": "property.boundary.area.hectares*2",
+            "defaults": {
+                "property.boundary.area.hectares": "0"
+            },
+            "formatOutputForAutomations": false
+        },
+        "type": 700
+    },
+    "5NwXOe2kl6": {
+        "data": {
+            "val": "designated",
+            "text": "Designated land",
+            "flags": [
+                "PRIOR_APPROVAL",
+                "DC-REQUIRED"
+            ]
+        },
+        "type": 200
+    },
+    "5TB6qVisoq": {
+        "data": {
+            "val": "LB-MISSING_INFO",
+            "text": "Missing information"
+        },
+        "type": 200
+    },
+    "5lzcg8luJT": {
+        "data": {
+            "val": "commercial.utility",
+            "text": "Utility (water, waste, electricity)"
+        },
+        "type": 200
+    },
+    "5yGblc1zi8": {
+        "data": {
+            "val": "commercial.education.other",
+            "text": "Other educational establishment"
+        },
+        "type": 200
+    },
+    "6FL5k5zovo": {
+        "data": {
+            "text": "This flow always need to live between 'Find Property' and 'About the Property'."
+        },
+        "type": 100
+    },
+    "6IQpHgCEso": {
+        "data": {
+            "val": "commercial.retail.shop.gardenCentre",
+            "text": "Garden centre"
+        },
+        "type": 200
+    },
+    "6TxMlBZqzW": {
+        "data": {
+            "val": "commercial.transport.terminal.bus",
+            "text": "Bus station"
+        },
+        "type": 200
+    },
+    "6ZTrmjer34": {
+        "data": {
+            "val": "commercial.community.prison.secureResidential",
+            "text": "Secure residential accommodation"
+        },
+        "type": 200
+    },
+    "6m7kgvL204": {
+        "data": {
+            "val": "PRIOR_APPROVAL",
+            "text": "Prior approval"
+        },
+        "type": 200
+    },
+    "6s4OYxRuxF": {
+        "data": {
+            "text": "[Not currently in CSV]"
+        },
+        "type": 100
+    },
+    "77aMg0KaeL": {
+        "data": {
+            "val": "commercial.retail.market",
+            "text": "Market"
+        },
+        "type": 200
+    },
+    "7MvdNl3XE8": {
+        "data": {
+            "val": "commercial.education",
+            "text": "Education"
+        },
+        "type": 200,
+        "edges": [
+            "MvRUSyqezC"
+        ]
+    },
+    "87KjOi5c82": {
+        "data": {
+            "val": "residential.dwelling.house",
+            "text": "House"
+        },
+        "type": 200,
+        "edges": [
+            "QgI87UIDEx"
+        ]
+    },
+    "9YqHTuXVjs": {
+        "data": {
+            "fn": "proposal.site",
+            "info": "<p>This outline identifies the location of the proposed changes on a map. This information is required for all planning applications. It is sometimes called a &apos;red line drawing&apos; or &apos;location plan&apos;.</p>",
+            "title": "Confirm your location plan",
+            "policyRef": "<p><a target=\"_blank\" rel=\"noopener noreferrer nofollow\" href=\"https://www.legislation.gov.uk/uksi/2015/595/article/7\">The Town and Country Planning (Development Management Procedure) (England) Order 2015</a>,</p><p><a target=\"_blank\" rel=\"noopener noreferrer nofollow\" href=\"https://www.gov.uk/government/collections/planning-practice-guidance\">Planning Practice Guidance (PPG)</a></p>",
+            "description": "<p>The red line shown below should include:</p><ul><li><p>the outline of your property boundary</p></li><li><p>any works outside the property boundary</p></li><li><p>areas that will be closed off or you&apos;ll need access to during the works</p></li></ul><p>If the red line already includes all these, select continue. If not, select More information for guidance on how to amend or redraw the outline.</p>",
+            "howMeasured": "<p>We have pre-populated the map with a red outline that includes the entire property using information from Land Registry.</p><p>In some cases, this outline might not include all the works or the areas that will be closed off. This might be because you&apos;re proposing works to a public highway (such as a dropped kerb), doing works that involve multiple properties, or works to a building that is part of a larger estate.</p><p>In these cases, you should amend the red outline by dragging the edges, or erase it by clicking the :wastebasket:-icon on the map and draw a new outline.</p><p></p><h1>How to draw and amend the outline</h1><ol><li><p>Move the cursor to the corner you want to start with and click or tap once.</p></li><li><p>Move the cursor to the next corner and click or tap.</p></li><li><p>Repeat until you have the shape you need.</p></li><li><p>Click or tap the last corner again to stop drawing.</p></li><li><p>To amend the outline, click or tap on a line and drag it into a new position.</p></li></ol><img src=\"https://api.editor.planx.uk/file/public/dni98ojg/Draw_Outline_2.gif\">",
+            "hideFileUpload": false,
+            "titleForUploading": "Upload a location plan",
+            "descriptionForUploading": "<p>Your location plan must:</p><ul><li><p>be based on an accurate, recognisable map</p></li><li><p>be drawn to a scale, labelled, and/or marked with a scale bar</p></li><li><p>show the site outline in red</p></li><li><p>include a<strong> </strong>north point</p></li></ul>"
+        },
+        "type": 10
+    },
+    "ABfyMaziTo": {
+        "data": {
+            "val": "commercial.transport.dock",
+            "text": "Harbour"
+        },
+        "type": 200
+    },
+    "Adop1mBxrE": {
+        "data": {
+            "fn": "property.type",
+            "val": "commercial.community",
+            "operation": "replace"
+        },
+        "type": 380
+    },
+    "AhFG90gq5e": {
+        "data": {
+            "val": "land.open.moor",
+            "text": "Heath or moorland"
+        },
+        "type": 200
+    },
+    "B2AMdGE1oz": {
+        "data": {
+            "fn": "property.type",
+            "val": "commercial.industrial",
+            "operation": "replace"
+        },
+        "type": 380
+    },
+    "C8JdGplv5s": {
+        "data": {
+            "img": "https://api.editor.planx.uk/file/public/btyxwr2j/housetypes_midterrace.png",
+            "val": "residential.dwelling.house.terrace",
+            "text": "Terrace"
+        },
+        "type": 200
+    },
+    "CINNX8Ik3s": {
+        "data": {
+            "val": "commercial.leisure.other",
+            "text": "Another leisure use"
+        },
+        "type": 200,
+        "edges": [
+            "tM7xu5U0Yr"
+        ]
+    },
+    "DvxdLfWY7y": {
+        "data": {
+            "fn": "property.type",
+            "val": "commercial.medical",
+            "operation": "replace"
+        },
+        "type": 380
+    },
+    "EneWmbOdWx": {
+        "data": {
+            "val": "industrial.mining",
+            "text": "Industrial mining"
+        },
+        "type": 200
+    },
+    "F10jdwjqbj": {
+        "data": {
+            "val": "commercial.transport",
+            "text": "Transport"
+        },
+        "type": 200,
+        "edges": [
+            "ua6mDtxpWH"
+        ]
+    },
+    "F7lubrvq95": {
+        "data": {
+            "val": "object.religious.building.temple",
+            "text": "Temple"
+        },
+        "type": 200
+    },
+    "FJnLFg4GBi": {
+        "data": {
+            "val": "commercial.transport.terminal.train",
+            "text": "Train station"
+        },
+        "type": 200
+    },
+    "Ff1vOjzAVD": {
+        "data": {
+            "val": "commercial.retail.showroom",
+            "text": "Showroom"
+        },
+        "type": 200
+    },
+    "GB3a9Uxm42": {
+        "data": {
+            "val": "commercial.leisure.museum",
+            "text": "Museum"
+        },
+        "type": 200
+    },
+    "GF2Ubxttu3": {
+        "data": {
+            "val": "object.religious.building",
+            "text": "Another type of religious building"
+        },
+        "type": 200
+    },
+    "GIfqiZqsPC": {
+        "data": {
+            "val": "commercial.community.other",
+            "text": "Another institutional building"
+        },
+        "type": 200,
+        "edges": [
+            "Adop1mBxrE"
+        ]
+    },
+    "GJZ7xULXqK": {
+        "data": {
+            "val": "commercial.industrial.extraction",
+            "text": "Extraction"
+        },
+        "type": 200
+    },
+    "GhtCWiIfnx": {
+        "data": {
+            "val": "military",
+            "text": "Military"
+        },
+        "type": 200
+    },
+    "GspcOr57zL": {
+        "data": {
+            "val": "commercial.office.workspace",
+            "text": "Office"
+        },
+        "type": 200
+    },
+    "HSVuNf2tZG": {
+        "data": {
+            "val": "PP-NOTICE",
+            "text": "Notice"
+        },
+        "type": 200
+    },
+    "HaOcUgqqqP": {
+        "data": {
+            "val": "object.religious.building.synagogue",
+            "text": "Synagogue"
+        },
+        "type": 200
+    },
+    "Hx11x57Zy8": {
+        "data": {
+            "val": "object.religious.building.church",
+            "text": "Church"
+        },
+        "type": 200
+    },
+    "I03hRPF3ck": {
+        "data": {
+            "fn": "property.type",
+            "text": "What type of property is it?",
+            "notes": "Added definition of HMO. \nHA",
+            "howMeasured": "<p><strong>Flats</strong> includes maisonettes (a flat with more than one storey that is within a shared building).</p><p><strong>A house in multiple occupation (HMO)</strong> has:</p><ul><li><p>at least 3 tenants living there, forming more than 1 household</p></li><li><p>a shared toilet, bathroom or kitchen facilities between tenants</p></li></ul>"
+        },
+        "type": 100,
+        "edges": [
+            "87KjOi5c82",
+            "2Z4Ah7QPvE",
+            "M9bF7tV5Mx",
+            "hrVQ3UrdMQ"
+        ]
+    },
+    "J4IXSAlPTw": {
+        "data": {
+            "val": "commercial.industrial.other",
+            "text": "Another industrial use"
+        },
+        "type": 200,
+        "edges": [
+            "B2AMdGE1oz"
+        ]
+    },
+    "JewE77gtFE": {
+        "data": {
+            "val": "commercial.office.broadcasting",
+            "text": "Broadcasting studio"
+        },
+        "type": 200
+    },
+    "JkyukIyZ5r": {
+        "data": {
+            "text": "What about garden of X property? For 'building X in the land around a building'?"
+        },
+        "type": 100
+    },
+    "KOBzBAzzNG": {
+        "data": {
+            "val": "commercial.community.prison",
+            "text": "Prison"
+        },
+        "type": 200
+    },
+    "KelsJUMvcF": {
+        "data": {
+            "val": "commercial.transport.air",
+            "text": "Airport or airfield"
+        },
+        "type": 200
+    },
+    "KhqvCr57zL": {
+        "data": {
+            "fn": "property.type",
+            "text": "What type of commercial property is it?"
+        },
+        "type": 100,
+        "edges": [
+            "GspcOr57zL",
+            "wenuhnHnzR",
+            "JewE77gtFE",
+            "kGyQVr57zL"
+        ]
+    },
+    "LT6T7RR5O3": {
+        "data": {
+            "val": "NO_APP_REQUIRED",
+            "text": "Permitted development"
+        },
+        "type": 200
+    },
+    "LU5xin8PHs": {
+        "data": {
+            "fn": "property.type",
+            "text": "Which of these best describes the use of the property?"
+        },
+        "type": 100,
+        "edges": [
+            "TCYyJ2dnVQ",
+            "xuFhs3Hqr9",
+            "jImvxS3FNw",
+            "7MvdNl3XE8",
+            "xtrFvDHgOI",
+            "1nHpe53Ytm",
+            "WVQ0zdfUXz",
+            "F10jdwjqbj",
+            "qEPAzJoB8Y",
+            "N1752okA56",
+            "3TJYlfAUz6",
+            "vXLzCpHPRs"
+        ]
+    },
+    "LZ5owtXc8R": {
+        "data": {
+            "val": "object.religious.building.minster",
+            "text": "Minster"
+        },
+        "type": 200
+    },
+    "LczMuHy8w6": {
+        "data": {
+            "val": "PP-NOT_DEVELOPMENT",
+            "text": "Not development"
+        },
+        "type": 200
+    },
+    "M25kTJaupX": {
+        "data": {
+            "fn": "proposal.site.area.half",
+            "title": "Half the site boundary",
+            "formula": "property.boundary.area/2",
+            "defaults": {
+                "property.boundary.area": "0"
+            },
+            "formatOutputForAutomations": false
+        },
+        "type": 700
+    },
+    "M7Y93oTya3": {
+        "data": {
+            "fn": "property.type",
+            "text": "What type of leisure property is it?"
+        },
+        "type": 100,
+        "edges": [
+            "vwLsi2H7oK",
+            "VCa3N3ujER",
+            "GB3a9Uxm42",
+            "OWqVZ4U2Wu",
+            "nNw3oBYWf9",
+            "NtMJjAqat0",
+            "3uLzlsc0DS",
+            "r2Y8ydTsCn",
+            "PcFmfgw6vr",
+            "CINNX8Ik3s"
+        ]
+    },
+    "M9bF7tV5Mx": {
+        "data": {
+            "val": "residential.HMO",
+            "text": "A house in multiple occupation (HMO)"
+        },
+        "type": 200
+    },
+    "MQzrk4KPRO": {
+        "data": {
+            "fn": "flag",
+            "category": "Listed building consent"
+        },
+        "type": 500,
+        "edges": [
+            "5TB6qVisoq",
+            "fx0w4IdBU3",
+            "zHeTwH6CaY",
+            "ik25RDDUyG",
+            "wgJ5dK7N7u"
+        ]
+    },
+    "MvRUSyqezC": {
+        "data": {
+            "fn": "property.type",
+            "text": "What type of educational building is it?",
+            "notes": "SEND: Education for children and young people aged 3-19 with complex physical disabilities and health needs"
+        },
+        "type": 100,
+        "edges": [
+            "orpJWHhk3f",
+            "vUwbhBmVob",
+            "q7bavn1mz3",
+            "Vv1i0rOiKk",
+            "twOdAbGD0c",
+            "ZOtL3MUARu",
+            "5yGblc1zi8"
+        ]
+    },
+    "N1752okA56": {
+        "data": {
+            "val": "land",
+            "text": "Land"
+        },
+        "type": 200,
+        "edges": [
+            "6s4OYxRuxF",
+            "v9MhybjSFf"
+        ]
+    },
+    "N8T7u2fedh": {
+        "data": {
+            "title": "Find the property",
+            "newAddressTitle": "Click or tap at where the property is on the map and name it below",
+            "allowNewAddresses": false,
+            "newAddressDescription": "You will need to select a location and provide a name to continue",
+            "newAddressDescriptionLabel": "Name the site"
+        },
+        "type": 9
+    },
+    "NRxZatvY3G": {
+        "data": {
+            "val": "land.agriculture",
+            "text": "Agricultural"
+        },
+        "type": 200
+    },
+    "NWT3CsFSCz": {
+        "data": {
+            "val": "commercial.industrial.light.storage",
+            "text": "Storage"
+        },
+        "type": 200
+    },
+    "NtMJjAqat0": {
+        "data": {
+            "val": "commercial.leisure.entertainment.cinema",
+            "text": "Cinema"
+        },
+        "type": 200
+    },
+    "OWqVZ4U2Wu": {
+        "data": {
+            "val": "commercial.leisure.sport",
+            "text": "Indoor or outdoor sport"
+        },
+        "type": 200
+    },
+    "PNoPwbkS2L": {
+        "data": {
+            "val": "object.religious.building.mosque",
+            "text": "Mosque"
+        },
+        "type": 200
+    },
+    "PXI9SWUFSM": {
+        "data": {
+            "tags": [],
+            "title": "About the property",
+            "description": "<p>This is the information we currently have about the property.</p><p>The blue line shows the <strong>outline</strong> of the property (known as the title boundary). If this looks incorrect, go back a step and <strong>check you have selected the correct address</strong>.</p><p>We use this outline to create the site boundary where the project will take place. If your project covers a different area, you can change or redraw the site boundary on the next page.</p>",
+            "showPropertyTypeOverride": true
+        },
+        "type": 12
+    },
+    "PcFmfgw6vr": {
+        "data": {
+            "val": "commercial.leisure.park.zoo",
+            "text": "Zoo or theme park"
+        },
+        "type": 200
+    },
+    "QF9PQ7c53U": {
+        "data": {
+            "text": "No flag result"
+        },
+        "type": 200
+    },
+    "QQYPyFijad": {
+        "data": {
+            "img": "https://api.editor.planx.uk/file/public/2jpkk6ei/housetypes_semiDetached.png",
+            "val": "residential.dwelling.house.semiDetached",
+            "text": "Semi-detached"
+        },
+        "type": 200
+    },
+    "QgI87UIDEx": {
+        "data": {
+            "fn": "property.type",
+            "text": "What type of house is it?",
+            "howMeasured": "<p><strong>A detached house</strong> is not joined to another property.</p><p><strong>A semi-detached house </strong>is joined to 1 other property which, in turn, is not attached to any other properties. So together, the 2 properties form a pair.</p><p><strong>A terrace</strong> is a building that forms part of a row of 3 or more adjoining properties. This includes buildings at the end of the row (an <strong>end terrace</strong>).</p>"
+        },
+        "type": 100,
+        "edges": [
+            "aJzng1LAVi",
+            "QQYPyFijad",
+            "C8JdGplv5s",
+            "jY5LKeMShO"
+        ]
+    },
+    "S50pYmgKlM": {
+        "data": {
+            "val": "flood",
+            "text": "Flood zone",
+            "flags": [
+                "PP-NOTICE",
+                "TR-NOT_REQUIRED"
+            ]
+        },
+        "type": 200,
+        "edges": [
+            "wvRHLsZyyk"
+        ]
+    },
+    "SKHnXGOeXP": {
+        "data": {
+            "val": "commercial.animals",
+            "text": "Vet,  kennels, cattery or stables"
+        },
+        "type": 200
+    },
+    "TCYyJ2dnVQ": {
+        "data": {
+            "val": "commercial.retail",
+            "text": "Retail and services"
+        },
+        "type": 200,
+        "edges": [
+            "ZA71kgL6Q2"
+        ]
+    },
+    "TEojcnNYlP": {
+        "data": {
+            "val": "other.leisure",
+            "text": "Sport or other leisure"
+        },
+        "type": 200
+    },
+    "U771mX7pcX": {
+        "data": {
+            "val": "residential.carParkingSpace",
+            "text": "Car parking for a residential property"
+        },
+        "type": 200
+    },
+    "URAW8XuIIp": {
+        "data": {
+            "val": "commercial.retail.restaurant",
+            "text": "Restaurant"
+        },
+        "type": 200
+    },
+    "UTrsADvRG0": {
+        "data": {
+            "val": "commercial.medical.other",
+            "text": "Another health or care use"
+        },
+        "type": 200,
+        "edges": [
+            "DvxdLfWY7y"
+        ]
+    },
+    "UW5C3zLAVR": {
+        "data": {
+            "fn": "property.type",
+            "val": "commercial.industrial",
+            "operation": "replace"
+        },
+        "type": 380
+    },
+    "VCa3N3ujER": {
+        "data": {
+            "val": "commercial.leisure.holiday",
+            "text": "Campsite"
+        },
+        "type": 200
+    },
+    "VQeVVLKA7Q": {
+        "data": {
+            "val": "land.unused",
+            "text": "Unused land"
+        },
+        "type": 200
+    },
+    "Vv1i0rOiKk": {
+        "data": {
+            "val": "commercial.education.college",
+            "text": "College"
+        },
+        "type": 200
+    },
+    "W5tCOXfKqp": {
+        "data": {
+            "val": "MISSING_INFO",
+            "text": "Missing information"
+        },
+        "type": 200
+    },
+    "W7N5RqjC7L": {
+        "data": {
+            "val": "commercial.community.court",
+            "text": "Law court"
+        },
+        "type": 200
+    },
+    "WVQ0zdfUXz": {
+        "data": {
+            "val": "commercial.medical",
+            "text": "Health and care"
+        },
+        "type": 200,
+        "edges": [
+            "mRevTOrtYj"
+        ]
+    },
+    "WViyJ3YQxi": {
+        "data": {
+            "val": "other.historic",
+            "text": "Historic site"
+        },
+        "type": 200
+    },
+    "WlBAHtMtuv": {
+        "data": {
+            "fn": "property.type",
+            "val": "commercial.transport",
+            "operation": "replace"
+        },
+        "type": 380
+    },
+    "XDlfXlSFJY": {
+        "data": {
+            "fn": "property.constraints.planning",
+            "title": "Planning constraints",
+            "dataValues": [
+                "article4",
+                "article4.caz",
+                "brownfieldSite",
+                "designated.AONB",
+                "designated.conservationArea",
+                "greenBelt",
+                "designated.nationalPark",
+                "designated.nationalPark.broads",
+                "designated.WHS",
+                "flood",
+                "listed",
+                "monument",
+                "nature.ASNW",
+                "nature.ramsarSite",
+                "nature.SAC",
+                "nature.SPA",
+                "nature.SSSI",
+                "registeredPark",
+                "tpo",
+                "road.classified"
+            ],
+            "disclaimer": "<p><strong>This page does not include information about historic planning conditions that may apply to this property.</strong></p>",
+            "description": "Planning constraints might limit how you can develop or use the property"
+        },
+        "type": 11
+    },
+    "XTgtfwSuLQ": {
+        "data": {
+            "fn": "property.type",
+            "text": "What type of institutional building is it?"
+        },
+        "type": 100,
+        "edges": [
+            "ZcTXKBc4vS",
+            "4xoUWkORDG",
+            "W7N5RqjC7L",
+            "KOBzBAzzNG",
+            "6ZTrmjer34",
+            "oAh53Sdhlf",
+            "GIfqiZqsPC"
+        ]
+    },
+    "XrXi3rlRSZ": {
+        "data": {
+            "val": "object.religious.building.chapel",
+            "text": "Chapel"
+        },
+        "type": 200
+    },
+    "Xz0qrhi8H7": {
+        "data": {
+            "fn": "property.constraints.planning",
+            "tags": [],
+            "text": "Which article 4s apply?",
+            "allRequired": false,
+            "neverAutoAnswer": false
+        },
+        "type": 105,
+        "edges": [
+            "2FoekDHPbA",
+            "3zhtpyYEE1",
+            "m8JEFawEKD"
+        ]
+    },
+    "Y2kRmeO81E": {
+        "data": {
+            "val": "land.allotment",
+            "text": "Allotment"
+        },
+        "type": 200
+    },
+    "YSoz99VKge": {
+        "data": {
+            "val": "object.religious.building.kingdomHall",
+            "text": "Kingdom Hall"
+        },
+        "type": 200
+    },
+    "YjzESqJ4qq": {
+        "data": {
+            "val": "commercial.retail.post",
+            "text": "Post office"
+        },
+        "type": 200
+    },
+    "Z9dOoU0dD1": {
+        "data": {
+            "fn": "flag",
+            "category": "Planning permission"
+        },
+        "type": 500,
+        "edges": [
+            "xkTXHHPGDf",
+            "W5tCOXfKqp",
+            "qrZ7hJFcwj",
+            "6m7kgvL204",
+            "HSVuNf2tZG",
+            "LT6T7RR5O3",
+            "LczMuHy8w6",
+            "QF9PQ7c53U"
+        ]
+    },
+    "ZA71kgL6Q2": {
+        "data": {
+            "fn": "property.type",
+            "text": "What type of retail unit is it?"
+        },
+        "type": 100,
+        "edges": [
+            "m6PbWCB1we",
+            "mGlGlqZNMY",
+            "xCcQJDKF1l",
+            "URAW8XuIIp",
+            "h4XLYS8afw",
+            "YjzESqJ4qq",
+            "3s74llQcam",
+            "77aMg0KaeL",
+            "Ff1vOjzAVD",
+            "3Pp2uvwRfG",
+            "6IQpHgCEso",
+            "4n7h4JzAJR"
+        ]
+    },
+    "ZOtL3MUARu": {
+        "data": {
+            "val": "commercial.education.specialNeeds",
+            "text": "Special educational needs"
+        },
+        "type": 200
+    },
+    "ZcTXKBc4vS": {
+        "data": {
+            "val": "commercial.community.wc",
+            "text": "Public WC"
+        },
+        "type": 200
+    },
+    "a0OE4T9hhz": {
+        "data": {
+            "val": "other.unsupported.travellingPersons",
+            "text": "Travellers site"
+        },
+        "type": 200
+    },
+    "aJzng1LAVi": {
+        "data": {
+            "img": "https://api.editor.planx.uk/file/public/pk8f4g4h/housetypes_detached.png",
+            "val": "residential.dwelling.house.detached",
+            "text": "Detached"
+        },
+        "type": 200
+    },
+    "b6Bd8rgmZ8": {
+        "data": {
+            "val": "land.development",
+            "text": "Development site"
+        },
+        "type": 200
+    },
+    "bKyYzKGOAe": {
+        "data": {
+            "val": "other.agriculture",
+            "text": "Agricultural support (pen, pit, ladder etc.)"
+        },
+        "type": 200
+    },
+    "bsPJXND9ig": {
+        "data": {
+            "val": "listed.grade.II*",
+            "text": "Grade II*"
+        },
+        "type": 200
+    },
+    "cLkrqEThSB": {
+        "data": {
+            "val": "alter.deck",
+            "text": "Add a deck"
+        },
+        "type": 200
+    },
+    "cR39C6xDzK": {
+        "data": {
+            "val": "commercial.transport.freight",
+            "text": "Freight handling facility (such as a shipping container port)"
+        },
+        "type": 200
+    },
+    "duTwH18KKr": {
+        "data": {
+            "val": "land.other",
+            "text": "Another land use"
+        },
+        "type": 200,
+        "edges": [
+            "3lblfduLSS"
+        ]
+    },
+    "eR4Uk4wds5": {
+        "data": {
+            "val": "object.religious.building.cathedral",
+            "text": "Cathedral"
+        },
+        "type": 200
+    },
+    "fFaIGwurhW": {
+        "data": {
+            "val": "land.forest",
+            "text": "Forestry"
+        },
+        "type": 200
+    },
+    "fHWLxi5ejZ": {
+        "data": {
+            "val": "commercial.transport.parking",
+            "text": "Car park"
+        },
+        "type": 200
+    },
+    "fR27RXqLNn": {
+        "data": {
+            "val": "listed.grade.II",
+            "text": "Grade II"
+        },
+        "type": 200
+    },
+    "fx0w4IdBU3": {
+        "data": {
+            "val": "LB-REQUIRED",
+            "text": "Required"
+        },
+        "type": 200
+    },
+    "gL3852rbg7": {
+        "data": {
+            "val": "commercial.medical.healthCentre",
+            "text": "Health centre"
+        },
+        "type": 200
+    },
+    "h4XLYS8afw": {
+        "data": {
+            "val": "commercial.retail.takeaway",
+            "text": "Food takeaway"
+        },
+        "type": 200
+    },
+    "hNvEwECRda": {
+        "data": {
+            "fn": "property.type.userProvided",
+            "type": "short",
+            "title": "What type of property is it?"
+        },
+        "type": 110
+    },
+    "hrVQ3UrdMQ": {
+        "data": {
+            "text": "Something else"
+        },
+        "type": 200,
+        "edges": [
+            "LU5xin8PHs"
+        ]
+    },
+    "ik25RDDUyG": {
+        "data": {
+            "val": "LB-NOT_REQUIRED",
+            "text": "Not required"
+        },
+        "type": 200
+    },
+    "jImvxS3FNw": {
+        "data": {
+            "val": "commercial.office",
+            "text": "Commercial"
+        },
+        "type": 200,
+        "edges": [
+            "KhqvCr57zL"
+        ]
+    },
+    "jY5LKeMShO": {
+        "data": {
+            "img": "https://api.editor.planx.uk/file/public/u0lwhiv2/housetypes_endterrace.png",
+            "val": "residential.dwelling.house.terrace",
+            "text": "End terrace"
+        },
+        "type": 200
+    },
+    "jtVZ3Xa3DE": {
+        "data": {
+            "fn": "property.constraints.planning",
+            "text": "Which grade listed buildings?",
+            "allRequired": false,
+            "neverAutoAnswer": false
+        },
+        "type": 105,
+        "edges": [
+            "rKeLQit5lP",
+            "fR27RXqLNn",
+            "bsPJXND9ig"
+        ]
+    },
+    "kGyQVr57zL": {
+        "data": {
+            "val": "commercial.office.other",
+            "text": "Something else"
+        },
+        "type": 200,
+        "edges": [
+            "mbOwaGPJuU"
+        ]
+    },
+    "m6PbWCB1we": {
+        "data": {
+            "val": "commercial.retail.shop",
+            "text": "Shop"
+        },
+        "type": 200
+    },
+    "m8JEFawEKD": {
+        "data": {
+            "val": "article4",
+            "text": "Something else"
+        },
+        "type": 200
+    },
+    "mGlGlqZNMY": {
+        "data": {
+            "val": "commercial.retail.licensedPremises",
+            "text": "Off-licence"
+        },
+        "type": 200
+    },
+    "mRViARNa4U": {
+        "data": {
+            "val": "commercial.medical.care.home",
+            "text": "Care home"
+        },
+        "type": 200
+    },
+    "mRevTOrtYj": {
+        "data": {
+            "fn": "property.type",
+            "text": "What type of medical or care building is it?"
+        },
+        "type": 100,
+        "edges": [
+            "tAEd8K9ih8",
+            "2MlqAY7JKX",
+            "gL3852rbg7",
+            "mRViARNa4U",
+            "y1vXEBLI3y",
+            "UTrsADvRG0"
+        ]
+    },
+    "mbOwaGPJuU": {
+        "data": {
+            "fn": "property.type",
+            "val": "commercial.office",
+            "operation": "replace"
+        },
+        "type": 380
+    },
+    "nAQtDxo6c4": {
+        "data": {
+            "val": "commercial.industrial.manufacturing",
+            "text": "Manufacturing"
+        },
+        "type": 200
+    },
+    "nNw3oBYWf9": {
+        "data": {
+            "val": "commercial.leisure.entertainment",
+            "text": "Entertainment"
+        },
+        "type": 200
+    },
+    "nxoyVfZGlZ": {
+        "data": {
+            "text": "Something else"
+        },
+        "type": 200
+    },
+    "oAh53Sdhlf": {
+        "data": {
+            "val": "commercial.community.cemetary",
+            "text": "Cemetery or crematorium"
+        },
+        "type": 200
+    },
+    "oIqbT6ofX4": {
+        "data": {
+            "val": "object.religious.building.gurdwara",
+            "text": "Gurdwara"
+        },
+        "type": 200
+    },
+    "ok2w6dmuEw": {
+        "data": {
+            "val": "object.religious.building.lychGate",
+            "text": "Lych Gate"
+        },
+        "type": 200
+    },
+    "orpJWHhk3f": {
+        "data": {
+            "val": "commercial.education.nursery",
+            "text": "Nursery"
+        },
+        "type": 200
+    },
+    "pk3SFkfK0r": {
+        "data": {
+            "val": "object.religious.building.stupa",
+            "text": "Stupa"
+        },
+        "type": 200
+    },
+    "q7bavn1mz3": {
+        "data": {
+            "val": "commercial.education.secondarySchool",
+            "text": "Secondary school"
+        },
+        "type": 200
+    },
+    "qEPAzJoB8Y": {
+        "data": {
+            "val": "commercial.agriculture",
+            "text": "Agriculture"
+        },
+        "type": 200
+    },
+    "qrZ7hJFcwj": {
+        "data": {
+            "val": "PLANNING_PERMISSION_REQUIRED",
+            "text": "Permission needed"
+        },
+        "type": 200
+    },
+    "r2Y8ydTsCn": {
+        "data": {
+            "val": "commercial.leisure.entertainment.exhibition",
+            "text": "Exhibition centre"
+        },
+        "type": 200
+    },
+    "r9hNgcu8xe": {
+        "data": {
+            "val": "flood.zone.1",
+            "text": "Zone 1 (Low)"
+        },
+        "type": 200
+    },
+    "rKeLQit5lP": {
+        "data": {
+            "val": "listed.grade.I",
+            "text": "Grade I"
+        },
+        "type": 200
+    },
+    "rQ3yeKMo3r": {
+        "data": {
+            "val": "alter.internal.loft",
+            "text": "Add a loft"
+        },
+        "type": 200
+    },
+    "sYZiGbSwXS": {
+        "data": {
+            "fn": "property.type",
+            "text": "What type of property is it?"
+        },
+        "type": 100,
+        "edges": [
+            "U771mX7pcX",
+            "GhtCWiIfnx",
+            "WViyJ3YQxi",
+            "SKHnXGOeXP",
+            "a0OE4T9hhz",
+            "bKyYzKGOAe",
+            "TEojcnNYlP",
+            "5lzcg8luJT",
+            "3FiKmXz0Ct"
+        ]
+    },
+    "tAEd8K9ih8": {
+        "data": {
+            "val": "commercial.medical.GP",
+            "text": "Doctors surgery / clinic (GP)"
+        },
+        "type": 200
+    },
+    "tM7xu5U0Yr": {
+        "data": {
+            "fn": "property.type",
+            "val": "commercial.leisure",
+            "operation": "replace"
+        },
+        "type": 380
+    },
+    "tUsd2VX0CE": {
+        "data": {
+            "val": "article4",
+            "text": "Article 4",
+            "flags": [
+                "PLANNING_PERMISSION_REQUIRED",
+                "EDGE_CASE"
+            ]
+        },
+        "type": 200,
+        "edges": [
+            "Xz0qrhi8H7"
+        ]
+    },
+    "twOdAbGD0c": {
+        "data": {
+            "val": "commercial.education.university",
+            "text": "University"
+        },
+        "type": 200
+    },
+    "uIciTYALsx": {
+        "data": {
+            "val": "alter.internal.mezzanine",
+            "text": "Add a mezzanine floor"
+        },
+        "type": 200
+    },
+    "ua6mDtxpWH": {
+        "data": {
+            "fn": "property.type",
+            "text": "What type of transport property is it?"
+        },
+        "type": 100,
+        "edges": [
+            "FJnLFg4GBi",
+            "6TxMlBZqzW",
+            "KelsJUMvcF",
+            "fHWLxi5ejZ",
+            "cR39C6xDzK",
+            "ABfyMaziTo",
+            "yScStbKFow"
+        ]
+    },
+    "v9MhybjSFf": {
+        "data": {
+            "fn": "property.type",
+            "text": "What type of land is it?"
+        },
+        "type": 100,
+        "edges": [
+            "NRxZatvY3G",
+            "fFaIGwurhW",
+            "xpaP7v9BUG",
+            "Y2kRmeO81E",
+            "yRuZtDETJk",
+            "AhFG90gq5e",
+            "02aNXeNi17",
+            "vfA4cZoPKS",
+            "b6Bd8rgmZ8",
+            "VQeVVLKA7Q",
+            "duTwH18KKr"
+        ]
+    },
+    "vEr4UyFu4u": {
+        "data": {
+            "fn": "proposal.projectType",
+            "text": "What type of project are you doing?",
+            "neverAutoAnswer": false
+        },
+        "type": 100,
+        "edges": [
+            "vuhp0uk862",
+            "cLkrqEThSB",
+            "uIciTYALsx",
+            "rQ3yeKMo3r",
+            "EneWmbOdWx",
+            "nxoyVfZGlZ"
+        ]
+    },
+    "vUwbhBmVob": {
+        "data": {
+            "val": "commercial.education.school",
+            "text": "School"
+        },
+        "type": 200
+    },
+    "vXLzCpHPRs": {
+        "data": {
+            "text": "Other"
+        },
+        "type": 200,
+        "edges": [
+            "sYZiGbSwXS"
+        ]
+    },
+    "vfA4cZoPKS": {
+        "data": {
+            "val": "land.water",
+            "text": "Water"
+        },
+        "type": 200
+    },
+    "vuhp0uk862": {
+        "data": {
+            "val": "ChangeOfUse",
+            "text": "Change of use"
+        },
+        "type": 200
+    },
+    "vwLsi2H7oK": {
+        "data": {
+            "val": "commercial.leisure.library",
+            "text": "Library"
+        },
+        "type": 200
+    },
+    "wenuhnHnzR": {
+        "data": {
+            "val": "commercial.office.workspace.film",
+            "text": "Film studio"
+        },
+        "type": 200
+    },
+    "wgJ5dK7N7u": {
+        "data": {
+            "text": "No flag result"
+        },
+        "type": 200
+    },
+    "wkNZj4EJuR": {
+        "data": {
+            "val": "object.religious.building.abbey",
+            "text": "Abbey"
+        },
+        "type": 200
+    },
+    "wvRHLsZyyk": {
+        "data": {
+            "fn": "property.constraints.planning",
+            "text": "Which risk level?",
+            "allRequired": false,
+            "neverAutoAnswer": false
+        },
+        "type": 105,
+        "edges": [
+            "r9hNgcu8xe",
+            "0FIHMM1vcO",
+            "x4Zma010vS"
+        ]
+    },
+    "x4Zma010vS": {
+        "data": {
+            "val": "flood.zone.3",
+            "text": "Zone 3 (High)"
+        },
+        "type": 200
+    },
+    "xCcQJDKF1l": {
+        "data": {
+            "val": "commercial.retail.services",
+            "text": "Bank or financial service"
+        },
+        "type": 200
+    },
+    "xHPFIDDV1V": {
+        "data": {
+            "val": "commercial.industrial.distribution",
+            "text": "Distribution"
+        },
+        "type": 200
+    },
+    "xkTXHHPGDf": {
+        "data": {
+            "val": "IMMUNE",
+            "text": "Immune"
+        },
+        "type": 200
+    },
+    "xpaP7v9BUG": {
+        "data": {
+            "val": "land.park",
+            "text": "Park"
+        },
+        "type": 200
+    },
+    "xtrFvDHgOI": {
+        "data": {
+            "val": "commercial.industrial",
+            "text": "Industrial"
+        },
+        "type": 200,
+        "edges": [
+            "1ElP19Mpqq"
+        ]
+    },
+    "xuFhs3Hqr9": {
+        "data": {
+            "val": "commercial.leisure",
+            "text": "Leisure and sport"
+        },
+        "type": 200,
+        "edges": [
+            "M7Y93oTya3"
+        ]
+    },
+    "y1vXEBLI3y": {
+        "data": {
+            "val": "commercial.medical.lab",
+            "text": "Medical, testing or research laboratory"
+        },
+        "type": 200
+    },
+    "yRuZtDETJk": {
+        "data": {
+            "val": "land.open",
+            "text": "Open space"
+        },
+        "type": 200
+    },
+    "yScStbKFow": {
+        "data": {
+            "val": "commercial.transport.other",
+            "text": "Another transport use"
+        },
+        "type": 200,
+        "edges": [
+            "WlBAHtMtuv"
+        ]
+    },
+    "zHeTwH6CaY": {
+        "data": {
+            "val": "LB-DE_MINIMIS",
+            "text": "De minimis"
+        },
+        "type": 200
+    },
+    "6689164d-2a5e-422f-8d6a-d3ea11a2fbb9": {
+        "data": {
+            "text": "opensystemslab/property-types",
+            "summary": null,
+            "publishedAt": "2024-08-14T16:47:14.79483+00:00",
+            "publishedBy": 84,
+            "publishedFlowId": 3961
+        },
+        "type": 300,
+        "edges": [
+            "6FL5k5zovo",
+            "JkyukIyZ5r",
+            "I03hRPF3ck"
+        ]
+    }
+};
+
+module.exports = { oldFlow };

--- a/jan2025_revisedSessions/tests/mocks/oldSession.js
+++ b/jan2025_revisedSessions/tests/mocks/oldSession.js
@@ -1,0 +1,2704 @@
+const oldSession = {
+  id: "9935e59d-904c-401f-bd1e-524ca91a1abc",
+  passport: {
+    "data": {
+      "_address": {
+        "uprn": "200003453172",
+        "usrn": "22500531",
+        "blpu_code": "2",
+        "latitude": 51.4842536,
+        "longitude": -0.0764166,
+        "organisation": null,
+        "sao": "FLAT 6",
+        "pao": "103",
+        "street": "COBOURG ROAD",
+        "town": "LONDON",
+        "postcode": "SE5 0HU",
+        "ward": "E05011109",
+        "x": 533660.36,
+        "y": 177898.47,
+        "planx_description": "Residential - Flat",
+        "planx_value": "residential.dwelling.flat",
+        "single_line_address": "FLAT 6, 103, COBOURG ROAD, LONDON, SOUTHWARK, SE5 0HU",
+        "title": "FLAT 6, 103, COBOURG ROAD, LONDON",
+        "source": "os"
+      },
+      "property.type": [
+        "residential.dwelling.flat"
+      ],
+      "property.localAuthorityDistrict": [
+        "Southwark"
+      ],
+      "property.region": [
+        "London"
+      ],
+      "property.boundary": {
+        "geometry": {
+          "type": "MultiPolygon",
+          "coordinates": [
+            [
+              [
+                [
+                  -0.076691,
+                  51.484197
+                ],
+                [
+                  -0.075933,
+                  51.484124
+                ],
+                [
+                  -0.075856,
+                  51.484369
+                ],
+                [
+                  -0.075889,
+                  51.484372
+                ],
+                [
+                  -0.0759,
+                  51.484324
+                ],
+                [
+                  -0.076391,
+                  51.484369
+                ],
+                [
+                  -0.076388,
+                  51.484383
+                ],
+                [
+                  -0.076644,
+                  51.484409
+                ],
+                [
+                  -0.076691,
+                  51.484197
+                ]
+              ]
+            ]
+          ]
+        },
+        "type": "Feature",
+        "properties": {
+          "entry-date": "2024-05-06",
+          "start-date": "2011-08-25",
+          "end-date": "",
+          "entity": 12000601059,
+          "name": "",
+          "dataset": "title-boundary",
+          "typology": "geography",
+          "reference": "52725257",
+          "prefix": "title-boundary",
+          "organisation-entity": "13"
+        }
+      },
+      "property.boundary.area": 1232.22,
+      "property.boundary.area.hectares": 0.123222,
+      "findProperty.action": "Selected an existing address",
+      "propertyInformation.action": "Accepted the property type",
+      "proposal.site": {
+        "geometry": {
+          "type": "MultiPolygon",
+          "coordinates": [
+            [
+              [
+                [
+                  -0.076691,
+                  51.484197
+                ],
+                [
+                  -0.075933,
+                  51.484124
+                ],
+                [
+                  -0.075856,
+                  51.484369
+                ],
+                [
+                  -0.075889,
+                  51.484372
+                ],
+                [
+                  -0.0759,
+                  51.484324
+                ],
+                [
+                  -0.076391,
+                  51.484369
+                ],
+                [
+                  -0.076388,
+                  51.484383
+                ],
+                [
+                  -0.076644,
+                  51.484409
+                ],
+                [
+                  -0.076691,
+                  51.484197
+                ]
+              ]
+            ]
+          ]
+        },
+        "type": "Feature",
+        "properties": {
+          "entry-date": "2024-05-06",
+          "start-date": "2011-08-25",
+          "end-date": "",
+          "entity": 12000601059,
+          "name": "",
+          "dataset": "title-boundary",
+          "typology": "geography",
+          "reference": "52725257",
+          "prefix": "title-boundary",
+          "organisation-entity": "13"
+        }
+      },
+      "proposal.site.buffered": {
+        "type": "Feature",
+        "properties": {
+          "entry-date": "2024-05-06",
+          "start-date": "2011-08-25",
+          "end-date": "",
+          "entity": 12000601059,
+          "name": "",
+          "dataset": "title-boundary",
+          "typology": "geography",
+          "reference": "52725257",
+          "prefix": "title-boundary",
+          "organisation-entity": "13"
+        },
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                -0.07840771069514788,
+                51.48434457711614
+              ],
+              [
+                -0.07842115842704286,
+                51.48413536783419
+              ],
+              [
+                -0.07836948082188315,
+                51.48392847894068
+              ],
+              [
+                -0.07825462393878962,
+                51.48373169794115
+              ],
+              [
+                -0.07808091182941154,
+                51.483552431772814
+              ],
+              [
+                -0.07785488367358213,
+                51.48339742802321
+              ],
+              [
+                -0.07758504757401118,
+                51.48327252097795
+              ],
+              [
+                -0.07728156028667897,
+                51.483182412050674
+              ],
+              [
+                -0.07695584494421384,
+                51.48313049285461
+              ],
+              [
+                -0.07619786224769512,
+                51.48305749456187
+              ],
+              [
+                -0.07586728536909972,
+                51.4830455917509
+              ],
+              [
+                -0.07553910763660865,
+                51.483073061902296
+              ],
+              [
+                -0.0752253103701215,
+                51.483138902119634
+              ],
+              [
+                -0.07493734998485325,
+                51.483240708662436
+              ],
+              [
+                -0.07468573980210308,
+                51.48337476468626
+              ],
+              [
+                -0.07447966625880034,
+                51.483536175916264
+              ],
+              [
+                -0.07432665351938529,
+                51.483719049304945
+              ],
+              [
+                -0.0742322887326799,
+                51.48391670815698
+              ],
+              [
+                -0.07415527994534045,
+                51.484161707043235
+              ],
+              [
+                -0.07412307707964114,
+                51.484378824770474
+              ],
+              [
+                -0.07416161468926359,
+                51.48459554194685
+              ],
+              [
+                -0.07426932058476096,
+                51.484803011794625
+              ],
+              [
+                -0.07444179886249265,
+                51.48499276491181
+              ],
+              [
+                -0.074672009221287,
+                51.48515705503473
+              ],
+              [
+                -0.07495055427489787,
+                51.485289175294774
+              ],
+              [
+                -0.0752660631451402,
+                51.485383732052064
+              ],
+              [
+                -0.07560565568040607,
+                51.48543686512013
+              ],
+              [
+                -0.07563865643674306,
+                51.48543986519039
+              ],
+              [
+                -0.07597871334451682,
+                51.485449737443865
+              ],
+              [
+                -0.07606783741935134,
+                51.48544134015071
+              ],
+              [
+                -0.07610903686861933,
+                51.48544811115062
+              ],
+              [
+                -0.07636504268921902,
+                51.48547411175793
+              ],
+              [
+                -0.07670939164615519,
+                51.48548741590888
+              ],
+              [
+                -0.07705114879260505,
+                51.48545797882999
+              ],
+              [
+                -0.07737676854911488,
+                51.48538696726444
+              ],
+              [
+                -0.0776733450725096,
+                51.48527719575741
+              ],
+              [
+                -0.07792912386259696,
+                51.48513301507986
+              ],
+              [
+                -0.0781339676929286,
+                51.48496013975597
+              ],
+              [
+                -0.0782797583884334,
+                51.48476542153637
+              ],
+              [
+                -0.07836071852417716,
+                51.48455657780224
+              ],
+              [
+                -0.07840771069514788,
+                51.48434457711614
+              ]
+            ]
+          ]
+        }
+      },
+      "proposal.site.area": 1232.22,
+      "proposal.site.hectares": 0.123222,
+      "drawBoundary.action": "Accepted the title boundary",
+      "proposal.site.area.half": 616.11,
+      "proposal.site.area.hectares.double": 0.246444,
+      "_constraints": [
+        {
+          "sourceRequest": "https://www.planning.data.gov.uk/entity.json?entries=current&geometry=MULTIPOLYGON+%28%28%28-0.076691+51.484197%2C+-0.075933+51.484124%2C+-0.075856+51.484369%2C+-0.075889+51.484372%2C+-0.0759+51.484324%2C+-0.076391+51.484369%2C+-0.076388+51.484383%2C+-0.076644+51.484409%2C+-0.076691+51.484197%29%29%29&geometry_relation=intersects&exclude_field=geometry%2Cpoint&limit=100&dataset=article-4-direction-area&dataset=central-activities-zone&dataset=brownfield-land&dataset=brownfield-site&dataset=area-of-outstanding-natural-beauty&dataset=conservation-area&dataset=green-belt&dataset=national-park&dataset=world-heritage-site&dataset=world-heritage-site-buffer-zone&dataset=flood-risk-zone&dataset=listed-building&dataset=listed-building-outline&dataset=scheduled-monument&dataset=ancient-woodland&dataset=ramsar&dataset=special-area-of-conservation&dataset=special-protection-area&dataset=site-of-special-scientific-interest&dataset=park-and-garden&dataset=tree&dataset=tree-preservation-order&dataset=tree-preservation-zone",
+          "constraints": {
+            "listed": {
+              "fn": "listed",
+              "value": true,
+              "text": "is, or is within, a Listed Building",
+              "data": [
+                {
+                  "entry-date": "2023-08-16",
+                  "start-date": "1954-06-30",
+                  "end-date": "",
+                  "entity": 42115431,
+                  "name": "New Peckham mosque (former church of St Mark)",
+                  "dataset": "listed-building-outline",
+                  "typology": "geography",
+                  "reference": "470793",
+                  "prefix": "listed-building-outline",
+                  "organisation-entity": "329",
+                  "document-url": "https://geomap.southwark.gov.uk/connect/analyst/Includes/ListedBuildings/SwarkLB205.pdf",
+                  "listed-building": "470793",
+                  "documentation-url": "https://geo.southwark.gov.uk/connect/analyst/Includes/ListedBuildings/SwarkLB205.pdf"
+                }
+              ],
+              "category": "Heritage and conservation"
+            },
+            "designated.conservationArea": {
+              "fn": "designated.conservationArea",
+              "value": true,
+              "text": "is in a Conservation Area",
+              "data": [
+                {
+                  "entry-date": "2024-07-11",
+                  "start-date": "1980-02-05",
+                  "end-date": "",
+                  "entity": 44010233,
+                  "name": "Cobourg Road",
+                  "dataset": "conservation-area",
+                  "typology": "geography",
+                  "reference": "19",
+                  "prefix": "conservation-area",
+                  "organisation-entity": "329",
+                  "document-url": "https://www.southwark.gov.uk/planning-and-building-control/design-and-conservation/conservation-areas?chapter=10",
+                  "designation-date": "1980-02-05",
+                  "documentation-url": "https://www.southwark.gov.uk/planning-and-building-control/design-and-conservation/conservation-areas?chapter=10"
+                }
+              ],
+              "category": "Heritage and conservation"
+            },
+            "flood": {
+              "fn": "flood",
+              "value": true,
+              "text": "is in a Flood Risk Zone",
+              "data": [
+                {
+                  "entry-date": "2023-08-24",
+                  "start-date": "",
+                  "end-date": "",
+                  "entity": 65106806,
+                  "name": "",
+                  "dataset": "flood-risk-zone",
+                  "typology": "geography",
+                  "reference": "106807",
+                  "prefix": "flood-risk-zone",
+                  "organisation-entity": "600009",
+                  "flood-risk-type": "Tidal Models",
+                  "flood-risk-level": "3"
+                },
+                {
+                  "entry-date": "2023-08-24",
+                  "start-date": "",
+                  "end-date": "",
+                  "entity": 65232137,
+                  "name": "",
+                  "dataset": "flood-risk-zone",
+                  "typology": "geography",
+                  "reference": "232138",
+                  "prefix": "flood-risk-zone",
+                  "organisation-entity": "600009",
+                  "flood-risk-type": "Tidal Models",
+                  "flood-risk-level": "2"
+                }
+              ],
+              "category": "Flooding"
+            },
+            "tpo": {
+              "fn": "tpo",
+              "value": true,
+              "text": "is in a Tree Preservation Order (TPO) Zone",
+              "data": [
+                {
+                  "entry-date": "2021-02-02",
+                  "start-date": "2021-02-02",
+                  "end-date": "",
+                  "entity": 7002050495,
+                  "name": "103 Coburg Road, SE5 0HU",
+                  "dataset": "tree",
+                  "typology": "geography",
+                  "reference": "537",
+                  "prefix": "tree",
+                  "organisation-entity": "329",
+                  "tree-preservation-order": "606",
+                  "tree-preservation-order-tree": "Individual"
+                }
+              ],
+              "category": "Trees"
+            },
+            "article4": {
+              "fn": "article4",
+              "value": false,
+              "text": "is not in an Article 4 direction area",
+              "category": "General policy"
+            },
+            "article4.caz": {
+              "fn": "article4.caz",
+              "value": false,
+              "text": "is not in the Central Activities Zone",
+              "category": "General policy"
+            },
+            "brownfieldSite": {
+              "fn": "brownfieldSite",
+              "value": false,
+              "text": "is not on Brownfield land",
+              "category": "General policy"
+            },
+            "designated.AONB": {
+              "fn": "designated.AONB",
+              "value": false,
+              "text": "is not in an Area of Outstanding Natural Beauty",
+              "category": "Heritage and conservation"
+            },
+            "greenBelt": {
+              "fn": "greenBelt",
+              "value": false,
+              "text": "is not in a Green Belt",
+              "category": "General policy"
+            },
+            "designated.nationalPark": {
+              "fn": "designated.nationalPark",
+              "value": false,
+              "text": "is not in a National Park",
+              "category": "Heritage and conservation"
+            },
+            "designated.nationalPark.broads": {
+              "fn": "designated.nationalPark.broads",
+              "value": false
+            },
+            "designated.WHS": {
+              "fn": "designated.WHS",
+              "value": false,
+              "text": "is not an UNESCO World Heritage Site",
+              "category": "Heritage and conservation"
+            },
+            "monument": {
+              "fn": "monument",
+              "value": false,
+              "text": "is not the site of a Scheduled Monument",
+              "category": "Heritage and conservation"
+            },
+            "nature.ASNW": {
+              "fn": "nature.ASNW",
+              "value": false,
+              "text": "is not in an Ancient Semi-Natural Woodland (ASNW)",
+              "category": "Ecology"
+            },
+            "nature.ramsarSite": {
+              "fn": "nature.ramsarSite",
+              "value": false,
+              "text": "is not in a Ramsar Site",
+              "category": "Ecology"
+            },
+            "nature.SAC": {
+              "fn": "nature.SAC",
+              "value": false,
+              "text": "is not in a Special Area of Conservation (SAC)",
+              "category": "Ecology"
+            },
+            "nature.SPA": {
+              "fn": "nature.SPA",
+              "value": false,
+              "text": "is not in a Special Protection Area (SPA)",
+              "category": "Ecology"
+            },
+            "nature.SSSI": {
+              "fn": "nature.SSSI",
+              "value": false,
+              "text": "is not a Site of Special Scientific Interest (SSSI)",
+              "category": "Ecology"
+            },
+            "registeredPark": {
+              "fn": "registeredPark",
+              "value": false,
+              "text": "is not in a Historic Park or Garden",
+              "category": "Heritage and conservation"
+            },
+            "designated": {
+              "value": true
+            },
+            "flood.zone.2": {
+              "fn": "flood.zone.2",
+              "value": true
+            },
+            "flood.zone.3": {
+              "fn": "flood.zone.3",
+              "value": true
+            },
+            "listed.grade.I": {
+              "fn": "listed.grade.I",
+              "value": false
+            },
+            "listed.grade.II": {
+              "fn": "listed.grade.II",
+              "value": false
+            },
+            "listed.grade.II*": {
+              "fn": "listed.grade.II*",
+              "value": false
+            }
+          },
+          "metadata": {
+            "article4": {
+              "entry-date": "",
+              "start-date": "",
+              "end-date": "",
+              "collection": "article-4-direction",
+              "dataset": "article-4-direction-area",
+              "description": "Orders made by the local planning authority to remove all or some of the permitted development rights on a site in order to protect it",
+              "name": "Article 4 direction area",
+              "plural": "Article 4 direction areas",
+              "prefix": "",
+              "text": "A local planning authority may create an [article 4 direction](https://www.gov.uk/guidance/when-is-permission-required#article-4-direction) to alter or remove [permitted development rights](https://www.gov.uk/government/publications/permitted-development-rights-for-householders-technical-guidance) from a building or area.\n\nEach [article 4 direction](/dataset/article-4-direction) may apply to one or more article 4 direction areas.",
+              "typology": "geography",
+              "wikidata": "",
+              "wikipedia": "",
+              "entities": "",
+              "themes": [
+                "heritage"
+              ],
+              "entity-count": {
+                "dataset": "article-4-direction-area",
+                "count": 2757
+              },
+              "paint-options": "",
+              "attribution": "crown-copyright",
+              "attribution-text": "© Crown copyright and database right 2025",
+              "licence": "ogl3",
+              "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+              "consideration": "article-4-directions",
+              "github-discussion": 30,
+              "entity-minimum": 7010000000,
+              "entity-maximum": 7019999999,
+              "phase": "beta",
+              "realm": "dataset",
+              "replacement-dataset": "",
+              "version": "3.0"
+            },
+            "article4.caz": {
+              "entry-date": "",
+              "start-date": "",
+              "end-date": "",
+              "collection": "central-activities-zone",
+              "dataset": "central-activities-zone",
+              "description": "",
+              "name": "Central activities zone",
+              "plural": "Central activities zones",
+              "prefix": "",
+              "text": "The [Greater London Authority](https://www.london.gov.uk/) (GLA) designates a central area of London with [implications for planning](https://www.london.gov.uk/what-we-do/planning/implementing-london-plan/london-plan-guidance-and-spgs/central-activities-zone)\nThis dataset combines data provided by the GLA with the boundary from the individual London boroughs.",
+              "typology": "geography",
+              "wikidata": "",
+              "wikipedia": "",
+              "entities": "",
+              "themes": [
+                "development"
+              ],
+              "entity-count": {
+                "dataset": "central-activities-zone",
+                "count": 10
+              },
+              "paint-options": "",
+              "attribution": "crown-copyright",
+              "attribution-text": "© Crown copyright and database right 2025",
+              "licence": "ogl3",
+              "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+              "consideration": "central-activty-zones",
+              "github-discussion": "",
+              "entity-minimum": 2200000,
+              "entity-maximum": 2299999,
+              "phase": "beta",
+              "realm": "dataset",
+              "replacement-dataset": "",
+              "version": "1.0"
+            },
+            "brownfieldSite": {
+              "entry-date": "",
+              "start-date": "",
+              "end-date": "",
+              "collection": "brownfield-site",
+              "dataset": "brownfield-site",
+              "description": "",
+              "name": "Brownfield site",
+              "plural": "Brownfield sites",
+              "prefix": "",
+              "text": "This is an experimental dataset of the boundaries of brownfield sites found on [data.gov.uk](https://www.data.gov.uk/search?q=brownfield)\nand local planning authority web sites.\nWe expect to combine this dataset with the [brownfield land](/dataset/brownfield-land) dataset in the near future.",
+              "typology": "geography",
+              "wikidata": "Q896586",
+              "wikipedia": "Brownfield_land",
+              "entities": "",
+              "themes": [
+                "development"
+              ],
+              "entity-count": {
+                "dataset": "brownfield-site",
+                "count": 2852
+              },
+              "paint-options": {
+                "colour": "#745729"
+              },
+              "attribution": "crown-copyright",
+              "attribution-text": "© Crown copyright and database right 2025",
+              "licence": "ogl3",
+              "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+              "consideration": "brownfield-land",
+              "github-discussion": 28,
+              "entity-minimum": 1800000,
+              "entity-maximum": 1899999,
+              "phase": "alpha",
+              "realm": "dataset",
+              "replacement-dataset": "",
+              "version": "1.0"
+            },
+            "designated.AONB": {
+              "entry-date": "",
+              "start-date": "",
+              "end-date": "",
+              "collection": "area-of-outstanding-natural-beauty",
+              "dataset": "area-of-outstanding-natural-beauty",
+              "description": "Land protected by law to conserve and enhance its natural beauty",
+              "name": "Area of outstanding natural beauty",
+              "plural": "Areas of outstanding natural beauty",
+              "prefix": "",
+              "text": "An area of outstanding natural beauty (AONB) as designated by [Natural England](https://www.gov.uk/government/organisations/natural-england).\n\nNatural England provides [guidance](https://www.gov.uk/guidance/protected-sites-and-areas-how-to-review-planning-applications) to help local authorities decide on planning applications in protected sites and areas.",
+              "typology": "geography",
+              "wikidata": "Q174945",
+              "wikipedia": "Area_of_Outstanding_Natural_Beauty",
+              "entities": "",
+              "themes": [
+                "environment"
+              ],
+              "entity-count": {
+                "dataset": "area-of-outstanding-natural-beauty",
+                "count": 34
+              },
+              "paint-options": {
+                "colour": "#d53880"
+              },
+              "attribution": "natural-england",
+              "attribution-text": "© Natural England copyright. Contains Ordnance Survey data © Crown copyright and database right 2025.",
+              "licence": "ogl3",
+              "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+              "consideration": "areas-of-outstanding-natural-beauty",
+              "github-discussion": 31,
+              "entity-minimum": 1000000,
+              "entity-maximum": 1099999,
+              "phase": "live",
+              "realm": "dataset",
+              "replacement-dataset": "",
+              "version": "1.0"
+            },
+            "designated.conservationArea": {
+              "entry-date": "",
+              "start-date": "",
+              "end-date": "",
+              "collection": "conservation-area",
+              "dataset": "conservation-area",
+              "description": "Special architectural or historic interest, the character or appearance of which it is desirable to preserve or enhance",
+              "name": "Conservation area",
+              "plural": "Conservation areas",
+              "prefix": "",
+              "text": "Local planning authorities are responsible for designating conservation areas, though [Historic England](https://historicengland.org.uk/) and the Secretary of State also have powers to create them.\n\nThis dataset also contains the boundaries of conservation areas from Historic England, as well as other data found on [data.gov.uk](https://www.data.gov.uk/search?q=conservation+area) and currently contains a number of duplicate areas we are working to remove.\n\nWe are also [working with a group of local planning authorities](/about/) to help them publish their conservation areas, and to develop a [data specification for conservation areas](https://www.digital-land.info/guidance/specifications/conservation-area).\n\nHistoric England provide [guidance](https://historicengland.org.uk/advice/your-home/owning-historic-property/conservation-area/) to help householders understand the implications of living in a conservation area for planning applications.",
+              "typology": "geography",
+              "wikidata": "Q5162904",
+              "wikipedia": "Conservation_area_(United_Kingdom)",
+              "entities": "",
+              "themes": [
+                "heritage"
+              ],
+              "entity-count": {
+                "dataset": "conservation-area",
+                "count": 11167
+              },
+              "paint-options": {
+                "colour": "#78AA00"
+              },
+              "attribution": "historic-england",
+              "attribution-text": "© Historic England 2025. Contains Ordnance Survey data © Crown copyright and database right 2025.\nThe Historic England GIS Data contained in this material was obtained on [date].\nThe most publicly available up to date Historic England GIS Data can be obtained from [HistoricEngland.org.uk](https://historicengland.org.uk).",
+              "licence": "ogl3",
+              "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+              "consideration": "conservation-areas",
+              "github-discussion": 33,
+              "entity-minimum": 44000000,
+              "entity-maximum": 44999999,
+              "phase": "beta",
+              "realm": "dataset",
+              "replacement-dataset": "",
+              "version": "3.0"
+            },
+            "greenBelt": {
+              "entry-date": "",
+              "start-date": "",
+              "end-date": "",
+              "collection": "green-belt",
+              "dataset": "green-belt",
+              "description": "",
+              "name": "Green belt",
+              "plural": "Green belt",
+              "prefix": "",
+              "text": "Boundaries for land designated by a local planning authority as being [green belt](https://www.gov.uk/guidance/green-belt),\ngrouped using the [greenbelt core](/dataset/greenbelt-core) category.\nThis data is compiled by the Department for Levelling Up, Housing and Communities for the purposes of gathering [green belt statistics](https://www.gov.uk/government/collections/green-belt-statistics).",
+              "typology": "geography",
+              "wikidata": "Q2734873",
+              "wikipedia": "Green_belt_(United_Kingdom)",
+              "entities": "",
+              "themes": [
+                "environment"
+              ],
+              "entity-count": {
+                "dataset": "green-belt",
+                "count": 185
+              },
+              "paint-options": {
+                "colour": "#85994b"
+              },
+              "attribution": "os-open-data",
+              "attribution-text": "Your use of OS OpenData is subject to the terms at http://os.uk/opendata/licence\nContains Ordnance Survey data © Crown copyright and database right 2025",
+              "licence": "ogl3",
+              "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+              "consideration": "greenbelt",
+              "github-discussion": 45,
+              "entity-minimum": 610000,
+              "entity-maximum": 610999,
+              "phase": "beta",
+              "realm": "dataset",
+              "replacement-dataset": "",
+              "version": "1.0"
+            },
+            "designated.nationalPark": {
+              "entry-date": "",
+              "start-date": "",
+              "end-date": "",
+              "collection": "national-park",
+              "dataset": "national-park",
+              "description": "",
+              "name": "National park",
+              "plural": "National parks",
+              "prefix": "statistical-geography",
+              "text": "The administrative boundaries of [national park authorities](/dataset/national-park-authority) in England as provided by the ONS for the purposes of producing statistics.",
+              "typology": "geography",
+              "wikidata": "Q60256727",
+              "wikipedia": "National_park",
+              "entities": "",
+              "themes": [
+                "heritage"
+              ],
+              "entity-count": {
+                "dataset": "national-park",
+                "count": 10
+              },
+              "paint-options": {
+                "colour": "#3DA52C"
+              },
+              "attribution": "ons-boundary",
+              "attribution-text": "Source: Office for National Statistics licensed under the Open Government Licence v.3.0\nContains OS data © Crown copyright and database right 2025",
+              "licence": "ogl3",
+              "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+              "consideration": "national-parks-and-the-broads",
+              "github-discussion": "",
+              "entity-minimum": 520000,
+              "entity-maximum": 520999,
+              "phase": "beta",
+              "realm": "dataset",
+              "replacement-dataset": "",
+              "version": "1.0"
+            },
+            "designated.WHS": {
+              "entry-date": "",
+              "start-date": "",
+              "end-date": "",
+              "collection": "historic-england",
+              "dataset": "world-heritage-site-buffer-zone",
+              "description": "",
+              "name": "World heritage site buffer zone",
+              "plural": "World heritage site buffer zones",
+              "prefix": "",
+              "text": "A [World Heritage Site](/dataset/world-heritage-site) may have a [buffer zone](https://whc.unesco.org/en/series/25/) with implications for planning.",
+              "typology": "geography",
+              "wikidata": "Q9259",
+              "wikipedia": "World_Heritage_Site",
+              "entities": "",
+              "themes": [
+                "heritage"
+              ],
+              "entity-count": {
+                "dataset": "world-heritage-site-buffer-zone",
+                "count": 9
+              },
+              "paint-options": {
+                "colour": "#EB1EE5",
+                "opacity": 0.2
+              },
+              "attribution": "historic-england",
+              "attribution-text": "© Historic England 2025. Contains Ordnance Survey data © Crown copyright and database right 2025.\nThe Historic England GIS Data contained in this material was obtained on [date].\nThe most publicly available up to date Historic England GIS Data can be obtained from [HistoricEngland.org.uk](https://historicengland.org.uk).",
+              "licence": "ogl3",
+              "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+              "consideration": "world-heritage-sites",
+              "github-discussion": "",
+              "entity-minimum": 16110000,
+              "entity-maximum": 16129999,
+              "phase": "beta",
+              "realm": "dataset",
+              "replacement-dataset": "",
+              "version": "1.0"
+            },
+            "flood": {
+              "entry-date": "",
+              "start-date": "",
+              "end-date": "",
+              "collection": "flood-risk-zone",
+              "dataset": "flood-risk-zone",
+              "description": "Area identified as being at risk of flooding from rivers or the sea",
+              "name": "Flood risk zone",
+              "plural": "Flood risk zones",
+              "prefix": "",
+              "text": "Flood zones are a guide produced by the Environment Agency to demonstrate the probability of river and sea flooding in areas across England. Flood zones are based on the likelihood of an area flooding, with flood zone 1 areas least likely to flood and flood zone 3 areas more likely to flood. \n\nThe flood zones were produced to help developers, councils and communities understand the flood risks present in specific locations or regions. Despite being a very useful indicator of an area’s flood risk, the zones cannot tell you whether a location will definitely flood or to what severity.",
+              "typology": "geography",
+              "wikidata": "",
+              "wikipedia": "",
+              "entities": "",
+              "themes": [
+                "environment"
+              ],
+              "entity-count": {
+                "dataset": "flood-risk-zone",
+                "count": 550621
+              },
+              "paint-options": "",
+              "attribution": "crown-copyright",
+              "attribution-text": "© Crown copyright and database right 2025",
+              "licence": "ogl3",
+              "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+              "consideration": "flood-risk-zones",
+              "github-discussion": 46,
+              "entity-minimum": 65000000,
+              "entity-maximum": 65999999,
+              "phase": "live",
+              "realm": "dataset",
+              "replacement-dataset": "",
+              "version": "1.0"
+            },
+            "listed": {
+              "entry-date": "",
+              "start-date": "",
+              "end-date": "",
+              "collection": "listed-building",
+              "dataset": "listed-building-outline",
+              "description": "boundary of a listed building",
+              "name": "Listed building outline",
+              "plural": "Listed building outlines",
+              "prefix": "",
+              "text": "The geospatial boundary for [listed buildings](https://historicengland.org.uk/listing/what-is-designation/listed-buildings) as designated by [Historic England](https://historicengland.org.uk/) as collected from local planning authorities.\n\nWe are [working with a group of local planning authorities](/about/) to help them publish their data to inform planning decisions, and to develop a [data specification for listed building outlines](https://www.digital-land.info/guidance/specifications/listed-building).\n\nWe expect to eventually merge this dataset with the [listed building](/dataset/listed-building) dataset.",
+              "typology": "geography",
+              "wikidata": "Q570600",
+              "wikipedia": "Listed_building",
+              "entities": "",
+              "themes": [
+                "heritage"
+              ],
+              "entity-count": {
+                "dataset": "listed-building-outline",
+                "count": 37369
+              },
+              "paint-options": {
+                "colour": "#F9C744"
+              },
+              "attribution": "crown-copyright",
+              "attribution-text": "© Crown copyright and database right 2025",
+              "licence": "ogl3",
+              "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+              "consideration": "listed-buildings",
+              "github-discussion": 44,
+              "entity-minimum": 42100000,
+              "entity-maximum": 43099999,
+              "phase": "alpha",
+              "realm": "dataset",
+              "replacement-dataset": "",
+              "version": "1.0"
+            },
+            "monument": {
+              "entry-date": "",
+              "start-date": "",
+              "end-date": "",
+              "collection": "historic-england",
+              "dataset": "scheduled-monument",
+              "description": "",
+              "name": "Scheduled monument",
+              "plural": "Scheduled monuments",
+              "prefix": "",
+              "text": "Historic buildings or sites such as Roman remains, burial mounds, castles, bridges, earthworks, the remains of deserted villages and industrial sites can be designated scheduled monuments by the Secretary of State for [Digital, Culture, Media and Sport](https://www.gov.uk/government/organisations/department-for-digital-culture-media-sport). \n\nThis list of scheduled monuments is kept and maintained by [Historic England](https://historicengland.org.uk/).",
+              "typology": "geography",
+              "wikidata": "Q219538",
+              "wikipedia": "Scheduled_monument",
+              "entities": "",
+              "themes": [
+                "heritage"
+              ],
+              "entity-count": {
+                "dataset": "scheduled-monument",
+                "count": 19999
+              },
+              "paint-options": {
+                "colour": "#0F9CDA"
+              },
+              "attribution": "historic-england",
+              "attribution-text": "© Historic England 2025. Contains Ordnance Survey data © Crown copyright and database right 2025.\nThe Historic England GIS Data contained in this material was obtained on [date].\nThe most publicly available up to date Historic England GIS Data can be obtained from [HistoricEngland.org.uk](https://historicengland.org.uk).",
+              "licence": "ogl3",
+              "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+              "consideration": "scheduled-monuments",
+              "github-discussion": "",
+              "entity-minimum": 13900000,
+              "entity-maximum": 13999999,
+              "phase": "beta",
+              "realm": "dataset",
+              "replacement-dataset": "",
+              "version": "1.0"
+            },
+            "nature.ASNW": {
+              "entry-date": "",
+              "start-date": "",
+              "end-date": "",
+              "collection": "ancient-woodland",
+              "dataset": "ancient-woodland",
+              "description": "An area that’s been wooded continuously since at least 1600 AD",
+              "name": "Ancient woodland",
+              "plural": "Ancient woodlands",
+              "prefix": "",
+              "text": "An area designated as ancient woodland by Natural England.\n\nNatural England and Forestry Commission [Guidance](https://www.gov.uk/guidance/ancient-woodland-and-veteran-trees-protection-surveys-licences)  is used in planning decisions.",
+              "typology": "geography",
+              "wikidata": "Q3078732",
+              "wikipedia": "Ancient_woodland",
+              "entities": "",
+              "themes": [
+                "environment"
+              ],
+              "entity-count": {
+                "dataset": "ancient-woodland",
+                "count": 44373
+              },
+              "paint-options": {
+                "colour": "#00703c",
+                "opacity": 0.2
+              },
+              "attribution": "natural-england",
+              "attribution-text": "© Natural England copyright. Contains Ordnance Survey data © Crown copyright and database right 2025.",
+              "licence": "ogl3",
+              "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+              "consideration": "ancient-woodlands",
+              "github-discussion": 32,
+              "entity-minimum": 110000000,
+              "entity-maximum": 129999999,
+              "phase": "live",
+              "realm": "dataset",
+              "replacement-dataset": "",
+              "version": "1.0"
+            },
+            "nature.ramsarSite": {
+              "entry-date": "",
+              "start-date": "",
+              "end-date": "",
+              "collection": "ramsar",
+              "dataset": "ramsar",
+              "description": "",
+              "name": "Ramsar site",
+              "plural": "Ramsar sites",
+              "prefix": "",
+              "text": "An internationally protected site listed as a wetland of international importance.\nRamsar sites are designated by [UNESCO](https://en.unesco.org/) and managed by [Natural England](https://www.gov.uk/government/organisations/natural-england).\n\nNatural England provides [guidance ](https://www.gov.uk/guidance/protected-sites-and-areas-how-to-review-planning-applications) to help local authorities decide on planning applications in protected sites and areas.",
+              "typology": "geography",
+              "wikidata": "",
+              "wikipedia": "",
+              "entities": "",
+              "themes": [
+                "environment"
+              ],
+              "entity-count": {
+                "dataset": "ramsar",
+                "count": 73
+              },
+              "paint-options": {
+                "colour": "#7fcdff"
+              },
+              "attribution": "natural-england",
+              "attribution-text": "© Natural England copyright. Contains Ordnance Survey data © Crown copyright and database right 2025.",
+              "licence": "ogl3",
+              "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+              "consideration": "ramsar",
+              "github-discussion": 41,
+              "entity-minimum": 612000,
+              "entity-maximum": 619999,
+              "phase": "beta",
+              "realm": "dataset",
+              "replacement-dataset": "",
+              "version": "1.0"
+            },
+            "nature.SAC": {
+              "entry-date": "",
+              "start-date": "",
+              "end-date": "",
+              "collection": "special-area-of-conservation",
+              "dataset": "special-area-of-conservation",
+              "description": "",
+              "name": "Special area of conservation",
+              "plural": "Special areas of conservation",
+              "prefix": "",
+              "text": "Special areas of conservation (SACs) are area of land which have been designated by\n[DEFRA](https://www.gov.uk/government/organisations/department-for-environment-food-rural-affairs),\nwith advice from the [Joint Nature Conservation Committee](https://jncc.gov.uk/),\nto protect specific habitats and species.\n\nDEFRA and [Natural England](https://www.gov.uk/government/organisations/natural-england) publish\n[guidance](https://www.gov.uk/guidance/protected-sites-and-areas-how-to-review-planning-applications)\non how to review planning applications in protected sites and areas.",
+              "typology": "geography",
+              "wikidata": "Q1191622",
+              "wikipedia": "Special_Area_of_Conservation",
+              "entities": "",
+              "themes": [
+                "environment"
+              ],
+              "entity-count": {
+                "dataset": "special-area-of-conservation",
+                "count": 260
+              },
+              "paint-options": {
+                "colour": "#7A8705"
+              },
+              "attribution": "natural-england",
+              "attribution-text": "© Natural England copyright. Contains Ordnance Survey data © Crown copyright and database right 2025.",
+              "licence": "ogl3",
+              "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+              "consideration": "special-areas-of-conservation",
+              "github-discussion": "",
+              "entity-minimum": 14800000,
+              "entity-maximum": 14899999,
+              "phase": "beta",
+              "realm": "dataset",
+              "replacement-dataset": "",
+              "version": "1.0"
+            },
+            "nature.SPA": {
+              "entry-date": "",
+              "start-date": "",
+              "end-date": "",
+              "collection": "special-protection-area",
+              "dataset": "special-protection-area",
+              "description": "",
+              "name": "Special protection area",
+              "plural": "Special protection areas",
+              "prefix": "",
+              "text": "[Special protection areas](https://naturalengland-defra.opendata.arcgis.com/maps/Defra::special-protection-areas-england/about) is an area designated \nfor the protection of birds and wildlife. This dataset is provided by [Natural England](https://www.gov.uk/government/organisations/natural-england).",
+              "typology": "geography",
+              "wikidata": "",
+              "wikipedia": "",
+              "entities": "",
+              "themes": [
+                "environment"
+              ],
+              "entity-count": {
+                "dataset": "special-protection-area",
+                "count": 88
+              },
+              "paint-options": "",
+              "attribution": "natural-england",
+              "attribution-text": "© Natural England copyright. Contains Ordnance Survey data © Crown copyright and database right 2025.",
+              "licence": "ogl3",
+              "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+              "consideration": "special-protection-areas",
+              "github-discussion": "",
+              "entity-minimum": 14900000,
+              "entity-maximum": 14999999,
+              "phase": "beta",
+              "realm": "dataset",
+              "replacement-dataset": "",
+              "version": "1.0"
+            },
+            "nature.SSSI": {
+              "entry-date": "",
+              "start-date": "",
+              "end-date": "",
+              "collection": "site-of-special-scientific-interest",
+              "dataset": "site-of-special-scientific-interest",
+              "description": "",
+              "name": "Site of special scientific interest",
+              "plural": "Sites of special scientific interest",
+              "prefix": "",
+              "text": "Sites of special scientific interest (SSSI) are nationally protected sites that have features such as wildlife or geology. \n\nSSSIs are designated by [Natural England](https://www.gov.uk/government/organisations/natural-england).\nThere is [guidance](https://www.gov.uk/guidance/protected-areas-sites-of-special-scientific-interest) to help local authorities decide on planning applications in protected SSSIs.",
+              "typology": "geography",
+              "wikidata": "Q422211",
+              "wikipedia": "Site_of_Special_Scientific_Interest",
+              "entities": "",
+              "themes": [
+                "environment"
+              ],
+              "entity-count": {
+                "dataset": "site-of-special-scientific-interest",
+                "count": 4129
+              },
+              "paint-options": {
+                "colour": "#308fac"
+              },
+              "attribution": "natural-england",
+              "attribution-text": "© Natural England copyright. Contains Ordnance Survey data © Crown copyright and database right 2025.",
+              "licence": "ogl3",
+              "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+              "consideration": "sites-of-special-scientific-interest",
+              "github-discussion": "",
+              "entity-minimum": 14500000,
+              "entity-maximum": 14599999,
+              "phase": "beta",
+              "realm": "dataset",
+              "replacement-dataset": "",
+              "version": "1.0"
+            },
+            "registeredPark": {
+              "entry-date": "",
+              "start-date": "",
+              "end-date": "",
+              "collection": "historic-england",
+              "dataset": "park-and-garden",
+              "description": "",
+              "name": "Historic parks and gardens",
+              "plural": "Parks and gardens",
+              "prefix": "",
+              "text": "Historic parks and gardens as listed by [Historic England](https://historicengland.org.uk/) in the [Register of Parks and Gardens of Special Historic Interest](https://historicengland.org.uk/listing/what-is-designation/registered-parks-and-gardens/).",
+              "typology": "geography",
+              "wikidata": "Q6975250",
+              "wikipedia": "Register_of_Historic_Parks_and_Gardens_of_Special_Historic_Interest_in_England",
+              "entities": "",
+              "themes": [
+                "environment",
+                "heritage"
+              ],
+              "entity-count": {
+                "dataset": "park-and-garden",
+                "count": 1716
+              },
+              "paint-options": {
+                "colour": "#0EB951"
+              },
+              "attribution": "historic-england",
+              "attribution-text": "© Historic England 2025. Contains Ordnance Survey data © Crown copyright and database right 2025.\nThe Historic England GIS Data contained in this material was obtained on [date].\nThe most publicly available up to date Historic England GIS Data can be obtained from [HistoricEngland.org.uk](https://historicengland.org.uk).",
+              "licence": "ogl3",
+              "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+              "consideration": "",
+              "github-discussion": "",
+              "entity-minimum": 11100000,
+              "entity-maximum": 11199999,
+              "phase": "beta",
+              "realm": "dataset",
+              "replacement-dataset": "",
+              "version": "1.0"
+            },
+            "tpo": {
+              "entry-date": "",
+              "start-date": "",
+              "end-date": "",
+              "collection": "tree-preservation-order",
+              "dataset": "tree-preservation-zone",
+              "description": "An area covered by a tree preservation order",
+              "name": "Tree preservation zone",
+              "plural": "Trees preservation zones",
+              "prefix": "",
+              "text": "A Tree Preservation Order (TPO) can be placed on single trees, groups of trees and even whole woodlands. Tree Preservation Orders are made by local planning authorities following [guidance](https://www.gov.uk/guidance/tree-preservation-orders-and-trees-in-conservation-areas) provided by the [Ministry of Housing, Communities and Local Governments](https://www.gov.uk/government/organisations/ministry-of-housing-communities-local-government).\n\nEach [tree preservation order](/dataset/tree-preservation-order) may apply to a number of tree preservation order zones, and a number of individual [trees](/dataset/tree).\n\nThis dataset contains data from [a small group of local planning authorities](/about/) who we are working with to develop a [data specification for tree preservation orders](https://www.digital-land.info/guidance/specifications/tree-preservation-order).",
+              "typology": "geography",
+              "wikidata": "Q10884",
+              "wikipedia": "Tree",
+              "entities": "",
+              "themes": [
+                "environment"
+              ],
+              "entity-count": {
+                "dataset": "tree-preservation-zone",
+                "count": 26713
+              },
+              "paint-options": "",
+              "attribution": "crown-copyright",
+              "attribution-text": "© Crown copyright and database right 2025",
+              "licence": "ogl3",
+              "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+              "consideration": "tree-preservation-orders",
+              "github-discussion": 43,
+              "entity-minimum": 19100000,
+              "entity-maximum": 29099999,
+              "phase": "beta",
+              "realm": "dataset",
+              "replacement-dataset": "",
+              "version": "2.0"
+            }
+          },
+          "planxRequest": "https://api.editor.planx.uk/gis/testing?geom=MULTIPOLYGON+%28%28%28-0.076691+51.484197%2C+-0.075933+51.484124%2C+-0.075856+51.484369%2C+-0.075889+51.484372%2C+-0.0759+51.484324%2C+-0.076391+51.484369%2C+-0.076388+51.484383%2C+-0.076644+51.484409%2C+-0.076691+51.484197%29%29%29&vals=article4%2Carticle4.caz%2CbrownfieldSite%2Cdesignated.AONB%2Cdesignated.conservationArea%2CgreenBelt%2Cdesignated.nationalPark%2Cdesignated.nationalPark.broads%2Cdesignated.WHS%2Cflood%2Clisted%2Cmonument%2Cnature.ASNW%2Cnature.ramsarSite%2Cnature.SAC%2Cnature.SPA%2Cnature.SSSI%2CregisteredPark%2Ctpo%2Croad.classified&analytics=false"
+        },
+        {
+          "sourceRequest": "https://api.os.uk/features/v1/wfs?service=WFS&request=GetFeature&version=2.0.0&typeNames=Highways_RoadLink&outputFormat=GEOJSON&srsName=urn%3Aogc%3Adef%3Acrs%3AEPSG%3A%3A4326&count=1&filter=%0A++++%3Cogc%3AFilter%3E%0A++++++%3Cogc%3APropertyIsLike+wildCard%3D%22%25%22+singleChar%3D%22%23%22+escapeChar%3D%22%21%22%3E%0A++++++++%3Cogc%3APropertyName%3EFormsPartOf%3C%2Fogc%3APropertyName%3E%0A++++++++%3Cogc%3ALiteral%3E%25Street%23usrn22500531%25%3C%2Fogc%3ALiteral%3E%0A++++++%3C%2Fogc%3APropertyIsLike%3E%0A++++%3C%2Fogc%3AFilter%3E%0A++&",
+          "metadata": {
+            "road.classified": {
+              "name": "Classified road",
+              "plural": "Classified roads",
+              "text": "This will effect your project if you are looking to add a dropped kerb. It may also impact some agricultural or forestry projects within 25 metres of a classified road."
+            }
+          },
+          "constraints": {
+            "road.classified": {
+              "fn": "road.classified",
+              "value": false,
+              "text": "is not on a Classified Road",
+              "category": "General policy"
+            }
+          },
+          "planxRequest": "https://api.editor.planx.uk/roads?usrn=22500531"
+        }
+      ],
+      "planningConstraints.action": "Accepted all planning constraints",
+      "_nots": {
+        "property.constraints.planning": [
+          "article4",
+          "article4.caz",
+          "article4.buckinghamshire.os262",
+          "article4.gateshead.saltwell.D4",
+          "article4.newcastle.saintPetersBasin3",
+          "brownfieldSite",
+          "designated.AONB",
+          "greenBelt",
+          "designated.nationalPark",
+          "designated.nationalPark.broads",
+          "designated.WHS",
+          "monument",
+          "nature.ASNW",
+          "nature.ramsarSite",
+          "nature.SAC",
+          "nature.SPA",
+          "nature.SSSI",
+          "registeredPark",
+          "listed.grade.I",
+          "listed.grade.II",
+          "listed.grade.II*",
+          "road.classified"
+        ]
+      },
+      "property.constraints.planning": [
+        "flood.zone.2",
+        "flood.zone.3",
+        "listed.grade.II",
+        "designated",
+        "listed",
+        "flood",
+        "designated.conservationArea",
+        "tpo"
+      ],
+      "proposal.projectType": [
+        "alter.internal.loft"
+      ],
+      "flag": [
+        "LB-DE_MINIMIS",
+        "PRIOR_APPROVAL"
+      ]
+    }
+  },
+  breadcrumbs: {
+    "N8T7u2fedh": {
+      "auto": false,
+      "data": {
+        "_address": {
+          "uprn": "200003453172",
+          "usrn": "22500531",
+          "blpu_code": "2",
+          "latitude": 51.4842536,
+          "longitude": -0.0764166,
+          "organisation": null,
+          "sao": "FLAT 6",
+          "pao": "103",
+          "street": "COBOURG ROAD",
+          "town": "LONDON",
+          "postcode": "SE5 0HU",
+          "ward": "E05011109",
+          "x": 533660.36,
+          "y": 177898.47,
+          "planx_description": "Residential - Flat",
+          "planx_value": "residential.dwelling.flat",
+          "single_line_address": "FLAT 6, 103, COBOURG ROAD, LONDON, SOUTHWARK, SE5 0HU",
+          "title": "FLAT 6, 103, COBOURG ROAD, LONDON",
+          "source": "os"
+        },
+        "property.type": [
+          "residential.dwelling.flat"
+        ],
+        "property.localAuthorityDistrict": [
+          "Southwark"
+        ],
+        "property.region": [
+          "London"
+        ],
+        "property.boundary": {
+          "geometry": {
+            "type": "MultiPolygon",
+            "coordinates": [
+              [
+                [
+                  [
+                    -0.076691,
+                    51.484197
+                  ],
+                  [
+                    -0.075933,
+                    51.484124
+                  ],
+                  [
+                    -0.075856,
+                    51.484369
+                  ],
+                  [
+                    -0.075889,
+                    51.484372
+                  ],
+                  [
+                    -0.0759,
+                    51.484324
+                  ],
+                  [
+                    -0.076391,
+                    51.484369
+                  ],
+                  [
+                    -0.076388,
+                    51.484383
+                  ],
+                  [
+                    -0.076644,
+                    51.484409
+                  ],
+                  [
+                    -0.076691,
+                    51.484197
+                  ]
+                ]
+              ]
+            ]
+          },
+          "type": "Feature",
+          "properties": {
+            "entry-date": "2024-05-06",
+            "start-date": "2011-08-25",
+            "end-date": "",
+            "entity": 12000601059,
+            "name": "",
+            "dataset": "title-boundary",
+            "typology": "geography",
+            "reference": "52725257",
+            "prefix": "title-boundary",
+            "organisation-entity": "13"
+          }
+        },
+        "property.boundary.area": 1232.22,
+        "property.boundary.area.hectares": 0.123222,
+        "findProperty.action": "Selected an existing address"
+      }
+    },
+    "6FL5k5zovo": {
+      "auto": true
+    },
+    "JkyukIyZ5r": {
+      "auto": true
+    },
+    "I03hRPF3ck": {
+      "auto": true,
+      "answers": [
+        "2Z4Ah7QPvE"
+      ]
+    },
+    "PXI9SWUFSM": {
+      "auto": false,
+      "data": {
+        "propertyInformation.action": "Accepted the property type"
+      }
+    },
+    "9YqHTuXVjs": {
+      "auto": false,
+      "data": {
+        "proposal.site": {
+          "geometry": {
+            "type": "MultiPolygon",
+            "coordinates": [
+              [
+                [
+                  [
+                    -0.076691,
+                    51.484197
+                  ],
+                  [
+                    -0.075933,
+                    51.484124
+                  ],
+                  [
+                    -0.075856,
+                    51.484369
+                  ],
+                  [
+                    -0.075889,
+                    51.484372
+                  ],
+                  [
+                    -0.0759,
+                    51.484324
+                  ],
+                  [
+                    -0.076391,
+                    51.484369
+                  ],
+                  [
+                    -0.076388,
+                    51.484383
+                  ],
+                  [
+                    -0.076644,
+                    51.484409
+                  ],
+                  [
+                    -0.076691,
+                    51.484197
+                  ]
+                ]
+              ]
+            ]
+          },
+          "type": "Feature",
+          "properties": {
+            "entry-date": "2024-05-06",
+            "start-date": "2011-08-25",
+            "end-date": "",
+            "entity": 12000601059,
+            "name": "",
+            "dataset": "title-boundary",
+            "typology": "geography",
+            "reference": "52725257",
+            "prefix": "title-boundary",
+            "organisation-entity": "13"
+          }
+        },
+        "proposal.site.buffered": {
+          "type": "Feature",
+          "properties": {
+            "entry-date": "2024-05-06",
+            "start-date": "2011-08-25",
+            "end-date": "",
+            "entity": 12000601059,
+            "name": "",
+            "dataset": "title-boundary",
+            "typology": "geography",
+            "reference": "52725257",
+            "prefix": "title-boundary",
+            "organisation-entity": "13"
+          },
+          "geometry": {
+            "type": "Polygon",
+            "coordinates": [
+              [
+                [
+                  -0.07840771069514788,
+                  51.48434457711614
+                ],
+                [
+                  -0.07842115842704286,
+                  51.48413536783419
+                ],
+                [
+                  -0.07836948082188315,
+                  51.48392847894068
+                ],
+                [
+                  -0.07825462393878962,
+                  51.48373169794115
+                ],
+                [
+                  -0.07808091182941154,
+                  51.483552431772814
+                ],
+                [
+                  -0.07785488367358213,
+                  51.48339742802321
+                ],
+                [
+                  -0.07758504757401118,
+                  51.48327252097795
+                ],
+                [
+                  -0.07728156028667897,
+                  51.483182412050674
+                ],
+                [
+                  -0.07695584494421384,
+                  51.48313049285461
+                ],
+                [
+                  -0.07619786224769512,
+                  51.48305749456187
+                ],
+                [
+                  -0.07586728536909972,
+                  51.4830455917509
+                ],
+                [
+                  -0.07553910763660865,
+                  51.483073061902296
+                ],
+                [
+                  -0.0752253103701215,
+                  51.483138902119634
+                ],
+                [
+                  -0.07493734998485325,
+                  51.483240708662436
+                ],
+                [
+                  -0.07468573980210308,
+                  51.48337476468626
+                ],
+                [
+                  -0.07447966625880034,
+                  51.483536175916264
+                ],
+                [
+                  -0.07432665351938529,
+                  51.483719049304945
+                ],
+                [
+                  -0.0742322887326799,
+                  51.48391670815698
+                ],
+                [
+                  -0.07415527994534045,
+                  51.484161707043235
+                ],
+                [
+                  -0.07412307707964114,
+                  51.484378824770474
+                ],
+                [
+                  -0.07416161468926359,
+                  51.48459554194685
+                ],
+                [
+                  -0.07426932058476096,
+                  51.484803011794625
+                ],
+                [
+                  -0.07444179886249265,
+                  51.48499276491181
+                ],
+                [
+                  -0.074672009221287,
+                  51.48515705503473
+                ],
+                [
+                  -0.07495055427489787,
+                  51.485289175294774
+                ],
+                [
+                  -0.0752660631451402,
+                  51.485383732052064
+                ],
+                [
+                  -0.07560565568040607,
+                  51.48543686512013
+                ],
+                [
+                  -0.07563865643674306,
+                  51.48543986519039
+                ],
+                [
+                  -0.07597871334451682,
+                  51.485449737443865
+                ],
+                [
+                  -0.07606783741935134,
+                  51.48544134015071
+                ],
+                [
+                  -0.07610903686861933,
+                  51.48544811115062
+                ],
+                [
+                  -0.07636504268921902,
+                  51.48547411175793
+                ],
+                [
+                  -0.07670939164615519,
+                  51.48548741590888
+                ],
+                [
+                  -0.07705114879260505,
+                  51.48545797882999
+                ],
+                [
+                  -0.07737676854911488,
+                  51.48538696726444
+                ],
+                [
+                  -0.0776733450725096,
+                  51.48527719575741
+                ],
+                [
+                  -0.07792912386259696,
+                  51.48513301507986
+                ],
+                [
+                  -0.0781339676929286,
+                  51.48496013975597
+                ],
+                [
+                  -0.0782797583884334,
+                  51.48476542153637
+                ],
+                [
+                  -0.07836071852417716,
+                  51.48455657780224
+                ],
+                [
+                  -0.07840771069514788,
+                  51.48434457711614
+                ]
+              ]
+            ]
+          }
+        },
+        "proposal.site.area": 1232.22,
+        "proposal.site.hectares": 0.123222,
+        "drawBoundary.action": "Accepted the title boundary"
+      }
+    },
+    "M25kTJaupX": {
+      "auto": true,
+      "data": {
+        "proposal.site.area.half": 616.11
+      }
+    },
+    "594ajFBA8C": {
+      "auto": true,
+      "data": {
+        "proposal.site.area.hectares.double": 0.246444
+      }
+    },
+    "XDlfXlSFJY": {
+      "auto": false,
+      "data": {
+        "_constraints": [
+          {
+            "sourceRequest": "https://www.planning.data.gov.uk/entity.json?entries=current&geometry=MULTIPOLYGON+%28%28%28-0.076691+51.484197%2C+-0.075933+51.484124%2C+-0.075856+51.484369%2C+-0.075889+51.484372%2C+-0.0759+51.484324%2C+-0.076391+51.484369%2C+-0.076388+51.484383%2C+-0.076644+51.484409%2C+-0.076691+51.484197%29%29%29&geometry_relation=intersects&exclude_field=geometry%2Cpoint&limit=100&dataset=article-4-direction-area&dataset=central-activities-zone&dataset=brownfield-land&dataset=brownfield-site&dataset=area-of-outstanding-natural-beauty&dataset=conservation-area&dataset=green-belt&dataset=national-park&dataset=world-heritage-site&dataset=world-heritage-site-buffer-zone&dataset=flood-risk-zone&dataset=listed-building&dataset=listed-building-outline&dataset=scheduled-monument&dataset=ancient-woodland&dataset=ramsar&dataset=special-area-of-conservation&dataset=special-protection-area&dataset=site-of-special-scientific-interest&dataset=park-and-garden&dataset=tree&dataset=tree-preservation-order&dataset=tree-preservation-zone",
+            "constraints": {
+              "listed": {
+                "fn": "listed",
+                "value": true,
+                "text": "is, or is within, a Listed Building",
+                "data": [
+                  {
+                    "entry-date": "2023-08-16",
+                    "start-date": "1954-06-30",
+                    "end-date": "",
+                    "entity": 42115431,
+                    "name": "New Peckham mosque (former church of St Mark)",
+                    "dataset": "listed-building-outline",
+                    "typology": "geography",
+                    "reference": "470793",
+                    "prefix": "listed-building-outline",
+                    "organisation-entity": "329",
+                    "document-url": "https://geomap.southwark.gov.uk/connect/analyst/Includes/ListedBuildings/SwarkLB205.pdf",
+                    "listed-building": "470793",
+                    "documentation-url": "https://geo.southwark.gov.uk/connect/analyst/Includes/ListedBuildings/SwarkLB205.pdf"
+                  }
+                ],
+                "category": "Heritage and conservation"
+              },
+              "designated.conservationArea": {
+                "fn": "designated.conservationArea",
+                "value": true,
+                "text": "is in a Conservation Area",
+                "data": [
+                  {
+                    "entry-date": "2024-07-11",
+                    "start-date": "1980-02-05",
+                    "end-date": "",
+                    "entity": 44010233,
+                    "name": "Cobourg Road",
+                    "dataset": "conservation-area",
+                    "typology": "geography",
+                    "reference": "19",
+                    "prefix": "conservation-area",
+                    "organisation-entity": "329",
+                    "document-url": "https://www.southwark.gov.uk/planning-and-building-control/design-and-conservation/conservation-areas?chapter=10",
+                    "designation-date": "1980-02-05",
+                    "documentation-url": "https://www.southwark.gov.uk/planning-and-building-control/design-and-conservation/conservation-areas?chapter=10"
+                  }
+                ],
+                "category": "Heritage and conservation"
+              },
+              "flood": {
+                "fn": "flood",
+                "value": true,
+                "text": "is in a Flood Risk Zone",
+                "data": [
+                  {
+                    "entry-date": "2023-08-24",
+                    "start-date": "",
+                    "end-date": "",
+                    "entity": 65106806,
+                    "name": "",
+                    "dataset": "flood-risk-zone",
+                    "typology": "geography",
+                    "reference": "106807",
+                    "prefix": "flood-risk-zone",
+                    "organisation-entity": "600009",
+                    "flood-risk-type": "Tidal Models",
+                    "flood-risk-level": "3"
+                  },
+                  {
+                    "entry-date": "2023-08-24",
+                    "start-date": "",
+                    "end-date": "",
+                    "entity": 65232137,
+                    "name": "",
+                    "dataset": "flood-risk-zone",
+                    "typology": "geography",
+                    "reference": "232138",
+                    "prefix": "flood-risk-zone",
+                    "organisation-entity": "600009",
+                    "flood-risk-type": "Tidal Models",
+                    "flood-risk-level": "2"
+                  }
+                ],
+                "category": "Flooding"
+              },
+              "tpo": {
+                "fn": "tpo",
+                "value": true,
+                "text": "is in a Tree Preservation Order (TPO) Zone",
+                "data": [
+                  {
+                    "entry-date": "2021-02-02",
+                    "start-date": "2021-02-02",
+                    "end-date": "",
+                    "entity": 7002050495,
+                    "name": "103 Coburg Road, SE5 0HU",
+                    "dataset": "tree",
+                    "typology": "geography",
+                    "reference": "537",
+                    "prefix": "tree",
+                    "organisation-entity": "329",
+                    "tree-preservation-order": "606",
+                    "tree-preservation-order-tree": "Individual"
+                  }
+                ],
+                "category": "Trees"
+              },
+              "article4": {
+                "fn": "article4",
+                "value": false,
+                "text": "is not in an Article 4 direction area",
+                "category": "General policy"
+              },
+              "article4.caz": {
+                "fn": "article4.caz",
+                "value": false,
+                "text": "is not in the Central Activities Zone",
+                "category": "General policy"
+              },
+              "brownfieldSite": {
+                "fn": "brownfieldSite",
+                "value": false,
+                "text": "is not on Brownfield land",
+                "category": "General policy"
+              },
+              "designated.AONB": {
+                "fn": "designated.AONB",
+                "value": false,
+                "text": "is not in an Area of Outstanding Natural Beauty",
+                "category": "Heritage and conservation"
+              },
+              "greenBelt": {
+                "fn": "greenBelt",
+                "value": false,
+                "text": "is not in a Green Belt",
+                "category": "General policy"
+              },
+              "designated.nationalPark": {
+                "fn": "designated.nationalPark",
+                "value": false,
+                "text": "is not in a National Park",
+                "category": "Heritage and conservation"
+              },
+              "designated.nationalPark.broads": {
+                "fn": "designated.nationalPark.broads",
+                "value": false
+              },
+              "designated.WHS": {
+                "fn": "designated.WHS",
+                "value": false,
+                "text": "is not an UNESCO World Heritage Site",
+                "category": "Heritage and conservation"
+              },
+              "monument": {
+                "fn": "monument",
+                "value": false,
+                "text": "is not the site of a Scheduled Monument",
+                "category": "Heritage and conservation"
+              },
+              "nature.ASNW": {
+                "fn": "nature.ASNW",
+                "value": false,
+                "text": "is not in an Ancient Semi-Natural Woodland (ASNW)",
+                "category": "Ecology"
+              },
+              "nature.ramsarSite": {
+                "fn": "nature.ramsarSite",
+                "value": false,
+                "text": "is not in a Ramsar Site",
+                "category": "Ecology"
+              },
+              "nature.SAC": {
+                "fn": "nature.SAC",
+                "value": false,
+                "text": "is not in a Special Area of Conservation (SAC)",
+                "category": "Ecology"
+              },
+              "nature.SPA": {
+                "fn": "nature.SPA",
+                "value": false,
+                "text": "is not in a Special Protection Area (SPA)",
+                "category": "Ecology"
+              },
+              "nature.SSSI": {
+                "fn": "nature.SSSI",
+                "value": false,
+                "text": "is not a Site of Special Scientific Interest (SSSI)",
+                "category": "Ecology"
+              },
+              "registeredPark": {
+                "fn": "registeredPark",
+                "value": false,
+                "text": "is not in a Historic Park or Garden",
+                "category": "Heritage and conservation"
+              },
+              "designated": {
+                "value": true
+              },
+              "flood.zone.2": {
+                "fn": "flood.zone.2",
+                "value": true
+              },
+              "flood.zone.3": {
+                "fn": "flood.zone.3",
+                "value": true
+              },
+              "listed.grade.I": {
+                "fn": "listed.grade.I",
+                "value": false
+              },
+              "listed.grade.II": {
+                "fn": "listed.grade.II",
+                "value": false
+              },
+              "listed.grade.II*": {
+                "fn": "listed.grade.II*",
+                "value": false
+              }
+            },
+            "metadata": {
+              "article4": {
+                "entry-date": "",
+                "start-date": "",
+                "end-date": "",
+                "collection": "article-4-direction",
+                "dataset": "article-4-direction-area",
+                "description": "Orders made by the local planning authority to remove all or some of the permitted development rights on a site in order to protect it",
+                "name": "Article 4 direction area",
+                "plural": "Article 4 direction areas",
+                "prefix": "",
+                "text": "A local planning authority may create an [article 4 direction](https://www.gov.uk/guidance/when-is-permission-required#article-4-direction) to alter or remove [permitted development rights](https://www.gov.uk/government/publications/permitted-development-rights-for-householders-technical-guidance) from a building or area.\n\nEach [article 4 direction](/dataset/article-4-direction) may apply to one or more article 4 direction areas.",
+                "typology": "geography",
+                "wikidata": "",
+                "wikipedia": "",
+                "entities": "",
+                "themes": [
+                  "heritage"
+                ],
+                "entity-count": {
+                  "dataset": "article-4-direction-area",
+                  "count": 2757
+                },
+                "paint-options": "",
+                "attribution": "crown-copyright",
+                "attribution-text": "© Crown copyright and database right 2025",
+                "licence": "ogl3",
+                "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+                "consideration": "article-4-directions",
+                "github-discussion": 30,
+                "entity-minimum": 7010000000,
+                "entity-maximum": 7019999999,
+                "phase": "beta",
+                "realm": "dataset",
+                "replacement-dataset": "",
+                "version": "3.0"
+              },
+              "article4.caz": {
+                "entry-date": "",
+                "start-date": "",
+                "end-date": "",
+                "collection": "central-activities-zone",
+                "dataset": "central-activities-zone",
+                "description": "",
+                "name": "Central activities zone",
+                "plural": "Central activities zones",
+                "prefix": "",
+                "text": "The [Greater London Authority](https://www.london.gov.uk/) (GLA) designates a central area of London with [implications for planning](https://www.london.gov.uk/what-we-do/planning/implementing-london-plan/london-plan-guidance-and-spgs/central-activities-zone)\nThis dataset combines data provided by the GLA with the boundary from the individual London boroughs.",
+                "typology": "geography",
+                "wikidata": "",
+                "wikipedia": "",
+                "entities": "",
+                "themes": [
+                  "development"
+                ],
+                "entity-count": {
+                  "dataset": "central-activities-zone",
+                  "count": 10
+                },
+                "paint-options": "",
+                "attribution": "crown-copyright",
+                "attribution-text": "© Crown copyright and database right 2025",
+                "licence": "ogl3",
+                "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+                "consideration": "central-activty-zones",
+                "github-discussion": "",
+                "entity-minimum": 2200000,
+                "entity-maximum": 2299999,
+                "phase": "beta",
+                "realm": "dataset",
+                "replacement-dataset": "",
+                "version": "1.0"
+              },
+              "brownfieldSite": {
+                "entry-date": "",
+                "start-date": "",
+                "end-date": "",
+                "collection": "brownfield-site",
+                "dataset": "brownfield-site",
+                "description": "",
+                "name": "Brownfield site",
+                "plural": "Brownfield sites",
+                "prefix": "",
+                "text": "This is an experimental dataset of the boundaries of brownfield sites found on [data.gov.uk](https://www.data.gov.uk/search?q=brownfield)\nand local planning authority web sites.\nWe expect to combine this dataset with the [brownfield land](/dataset/brownfield-land) dataset in the near future.",
+                "typology": "geography",
+                "wikidata": "Q896586",
+                "wikipedia": "Brownfield_land",
+                "entities": "",
+                "themes": [
+                  "development"
+                ],
+                "entity-count": {
+                  "dataset": "brownfield-site",
+                  "count": 2852
+                },
+                "paint-options": {
+                  "colour": "#745729"
+                },
+                "attribution": "crown-copyright",
+                "attribution-text": "© Crown copyright and database right 2025",
+                "licence": "ogl3",
+                "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+                "consideration": "brownfield-land",
+                "github-discussion": 28,
+                "entity-minimum": 1800000,
+                "entity-maximum": 1899999,
+                "phase": "alpha",
+                "realm": "dataset",
+                "replacement-dataset": "",
+                "version": "1.0"
+              },
+              "designated.AONB": {
+                "entry-date": "",
+                "start-date": "",
+                "end-date": "",
+                "collection": "area-of-outstanding-natural-beauty",
+                "dataset": "area-of-outstanding-natural-beauty",
+                "description": "Land protected by law to conserve and enhance its natural beauty",
+                "name": "Area of outstanding natural beauty",
+                "plural": "Areas of outstanding natural beauty",
+                "prefix": "",
+                "text": "An area of outstanding natural beauty (AONB) as designated by [Natural England](https://www.gov.uk/government/organisations/natural-england).\n\nNatural England provides [guidance](https://www.gov.uk/guidance/protected-sites-and-areas-how-to-review-planning-applications) to help local authorities decide on planning applications in protected sites and areas.",
+                "typology": "geography",
+                "wikidata": "Q174945",
+                "wikipedia": "Area_of_Outstanding_Natural_Beauty",
+                "entities": "",
+                "themes": [
+                  "environment"
+                ],
+                "entity-count": {
+                  "dataset": "area-of-outstanding-natural-beauty",
+                  "count": 34
+                },
+                "paint-options": {
+                  "colour": "#d53880"
+                },
+                "attribution": "natural-england",
+                "attribution-text": "© Natural England copyright. Contains Ordnance Survey data © Crown copyright and database right 2025.",
+                "licence": "ogl3",
+                "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+                "consideration": "areas-of-outstanding-natural-beauty",
+                "github-discussion": 31,
+                "entity-minimum": 1000000,
+                "entity-maximum": 1099999,
+                "phase": "live",
+                "realm": "dataset",
+                "replacement-dataset": "",
+                "version": "1.0"
+              },
+              "designated.conservationArea": {
+                "entry-date": "",
+                "start-date": "",
+                "end-date": "",
+                "collection": "conservation-area",
+                "dataset": "conservation-area",
+                "description": "Special architectural or historic interest, the character or appearance of which it is desirable to preserve or enhance",
+                "name": "Conservation area",
+                "plural": "Conservation areas",
+                "prefix": "",
+                "text": "Local planning authorities are responsible for designating conservation areas, though [Historic England](https://historicengland.org.uk/) and the Secretary of State also have powers to create them.\n\nThis dataset also contains the boundaries of conservation areas from Historic England, as well as other data found on [data.gov.uk](https://www.data.gov.uk/search?q=conservation+area) and currently contains a number of duplicate areas we are working to remove.\n\nWe are also [working with a group of local planning authorities](/about/) to help them publish their conservation areas, and to develop a [data specification for conservation areas](https://www.digital-land.info/guidance/specifications/conservation-area).\n\nHistoric England provide [guidance](https://historicengland.org.uk/advice/your-home/owning-historic-property/conservation-area/) to help householders understand the implications of living in a conservation area for planning applications.",
+                "typology": "geography",
+                "wikidata": "Q5162904",
+                "wikipedia": "Conservation_area_(United_Kingdom)",
+                "entities": "",
+                "themes": [
+                  "heritage"
+                ],
+                "entity-count": {
+                  "dataset": "conservation-area",
+                  "count": 11167
+                },
+                "paint-options": {
+                  "colour": "#78AA00"
+                },
+                "attribution": "historic-england",
+                "attribution-text": "© Historic England 2025. Contains Ordnance Survey data © Crown copyright and database right 2025.\nThe Historic England GIS Data contained in this material was obtained on [date].\nThe most publicly available up to date Historic England GIS Data can be obtained from [HistoricEngland.org.uk](https://historicengland.org.uk).",
+                "licence": "ogl3",
+                "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+                "consideration": "conservation-areas",
+                "github-discussion": 33,
+                "entity-minimum": 44000000,
+                "entity-maximum": 44999999,
+                "phase": "beta",
+                "realm": "dataset",
+                "replacement-dataset": "",
+                "version": "3.0"
+              },
+              "greenBelt": {
+                "entry-date": "",
+                "start-date": "",
+                "end-date": "",
+                "collection": "green-belt",
+                "dataset": "green-belt",
+                "description": "",
+                "name": "Green belt",
+                "plural": "Green belt",
+                "prefix": "",
+                "text": "Boundaries for land designated by a local planning authority as being [green belt](https://www.gov.uk/guidance/green-belt),\ngrouped using the [greenbelt core](/dataset/greenbelt-core) category.\nThis data is compiled by the Department for Levelling Up, Housing and Communities for the purposes of gathering [green belt statistics](https://www.gov.uk/government/collections/green-belt-statistics).",
+                "typology": "geography",
+                "wikidata": "Q2734873",
+                "wikipedia": "Green_belt_(United_Kingdom)",
+                "entities": "",
+                "themes": [
+                  "environment"
+                ],
+                "entity-count": {
+                  "dataset": "green-belt",
+                  "count": 185
+                },
+                "paint-options": {
+                  "colour": "#85994b"
+                },
+                "attribution": "os-open-data",
+                "attribution-text": "Your use of OS OpenData is subject to the terms at http://os.uk/opendata/licence\nContains Ordnance Survey data © Crown copyright and database right 2025",
+                "licence": "ogl3",
+                "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+                "consideration": "greenbelt",
+                "github-discussion": 45,
+                "entity-minimum": 610000,
+                "entity-maximum": 610999,
+                "phase": "beta",
+                "realm": "dataset",
+                "replacement-dataset": "",
+                "version": "1.0"
+              },
+              "designated.nationalPark": {
+                "entry-date": "",
+                "start-date": "",
+                "end-date": "",
+                "collection": "national-park",
+                "dataset": "national-park",
+                "description": "",
+                "name": "National park",
+                "plural": "National parks",
+                "prefix": "statistical-geography",
+                "text": "The administrative boundaries of [national park authorities](/dataset/national-park-authority) in England as provided by the ONS for the purposes of producing statistics.",
+                "typology": "geography",
+                "wikidata": "Q60256727",
+                "wikipedia": "National_park",
+                "entities": "",
+                "themes": [
+                  "heritage"
+                ],
+                "entity-count": {
+                  "dataset": "national-park",
+                  "count": 10
+                },
+                "paint-options": {
+                  "colour": "#3DA52C"
+                },
+                "attribution": "ons-boundary",
+                "attribution-text": "Source: Office for National Statistics licensed under the Open Government Licence v.3.0\nContains OS data © Crown copyright and database right 2025",
+                "licence": "ogl3",
+                "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+                "consideration": "national-parks-and-the-broads",
+                "github-discussion": "",
+                "entity-minimum": 520000,
+                "entity-maximum": 520999,
+                "phase": "beta",
+                "realm": "dataset",
+                "replacement-dataset": "",
+                "version": "1.0"
+              },
+              "designated.WHS": {
+                "entry-date": "",
+                "start-date": "",
+                "end-date": "",
+                "collection": "historic-england",
+                "dataset": "world-heritage-site-buffer-zone",
+                "description": "",
+                "name": "World heritage site buffer zone",
+                "plural": "World heritage site buffer zones",
+                "prefix": "",
+                "text": "A [World Heritage Site](/dataset/world-heritage-site) may have a [buffer zone](https://whc.unesco.org/en/series/25/) with implications for planning.",
+                "typology": "geography",
+                "wikidata": "Q9259",
+                "wikipedia": "World_Heritage_Site",
+                "entities": "",
+                "themes": [
+                  "heritage"
+                ],
+                "entity-count": {
+                  "dataset": "world-heritage-site-buffer-zone",
+                  "count": 9
+                },
+                "paint-options": {
+                  "colour": "#EB1EE5",
+                  "opacity": 0.2
+                },
+                "attribution": "historic-england",
+                "attribution-text": "© Historic England 2025. Contains Ordnance Survey data © Crown copyright and database right 2025.\nThe Historic England GIS Data contained in this material was obtained on [date].\nThe most publicly available up to date Historic England GIS Data can be obtained from [HistoricEngland.org.uk](https://historicengland.org.uk).",
+                "licence": "ogl3",
+                "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+                "consideration": "world-heritage-sites",
+                "github-discussion": "",
+                "entity-minimum": 16110000,
+                "entity-maximum": 16129999,
+                "phase": "beta",
+                "realm": "dataset",
+                "replacement-dataset": "",
+                "version": "1.0"
+              },
+              "flood": {
+                "entry-date": "",
+                "start-date": "",
+                "end-date": "",
+                "collection": "flood-risk-zone",
+                "dataset": "flood-risk-zone",
+                "description": "Area identified as being at risk of flooding from rivers or the sea",
+                "name": "Flood risk zone",
+                "plural": "Flood risk zones",
+                "prefix": "",
+                "text": "Flood zones are a guide produced by the Environment Agency to demonstrate the probability of river and sea flooding in areas across England. Flood zones are based on the likelihood of an area flooding, with flood zone 1 areas least likely to flood and flood zone 3 areas more likely to flood. \n\nThe flood zones were produced to help developers, councils and communities understand the flood risks present in specific locations or regions. Despite being a very useful indicator of an area’s flood risk, the zones cannot tell you whether a location will definitely flood or to what severity.",
+                "typology": "geography",
+                "wikidata": "",
+                "wikipedia": "",
+                "entities": "",
+                "themes": [
+                  "environment"
+                ],
+                "entity-count": {
+                  "dataset": "flood-risk-zone",
+                  "count": 550621
+                },
+                "paint-options": "",
+                "attribution": "crown-copyright",
+                "attribution-text": "© Crown copyright and database right 2025",
+                "licence": "ogl3",
+                "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+                "consideration": "flood-risk-zones",
+                "github-discussion": 46,
+                "entity-minimum": 65000000,
+                "entity-maximum": 65999999,
+                "phase": "live",
+                "realm": "dataset",
+                "replacement-dataset": "",
+                "version": "1.0"
+              },
+              "listed": {
+                "entry-date": "",
+                "start-date": "",
+                "end-date": "",
+                "collection": "listed-building",
+                "dataset": "listed-building-outline",
+                "description": "boundary of a listed building",
+                "name": "Listed building outline",
+                "plural": "Listed building outlines",
+                "prefix": "",
+                "text": "The geospatial boundary for [listed buildings](https://historicengland.org.uk/listing/what-is-designation/listed-buildings) as designated by [Historic England](https://historicengland.org.uk/) as collected from local planning authorities.\n\nWe are [working with a group of local planning authorities](/about/) to help them publish their data to inform planning decisions, and to develop a [data specification for listed building outlines](https://www.digital-land.info/guidance/specifications/listed-building).\n\nWe expect to eventually merge this dataset with the [listed building](/dataset/listed-building) dataset.",
+                "typology": "geography",
+                "wikidata": "Q570600",
+                "wikipedia": "Listed_building",
+                "entities": "",
+                "themes": [
+                  "heritage"
+                ],
+                "entity-count": {
+                  "dataset": "listed-building-outline",
+                  "count": 37369
+                },
+                "paint-options": {
+                  "colour": "#F9C744"
+                },
+                "attribution": "crown-copyright",
+                "attribution-text": "© Crown copyright and database right 2025",
+                "licence": "ogl3",
+                "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+                "consideration": "listed-buildings",
+                "github-discussion": 44,
+                "entity-minimum": 42100000,
+                "entity-maximum": 43099999,
+                "phase": "alpha",
+                "realm": "dataset",
+                "replacement-dataset": "",
+                "version": "1.0"
+              },
+              "monument": {
+                "entry-date": "",
+                "start-date": "",
+                "end-date": "",
+                "collection": "historic-england",
+                "dataset": "scheduled-monument",
+                "description": "",
+                "name": "Scheduled monument",
+                "plural": "Scheduled monuments",
+                "prefix": "",
+                "text": "Historic buildings or sites such as Roman remains, burial mounds, castles, bridges, earthworks, the remains of deserted villages and industrial sites can be designated scheduled monuments by the Secretary of State for [Digital, Culture, Media and Sport](https://www.gov.uk/government/organisations/department-for-digital-culture-media-sport). \n\nThis list of scheduled monuments is kept and maintained by [Historic England](https://historicengland.org.uk/).",
+                "typology": "geography",
+                "wikidata": "Q219538",
+                "wikipedia": "Scheduled_monument",
+                "entities": "",
+                "themes": [
+                  "heritage"
+                ],
+                "entity-count": {
+                  "dataset": "scheduled-monument",
+                  "count": 19999
+                },
+                "paint-options": {
+                  "colour": "#0F9CDA"
+                },
+                "attribution": "historic-england",
+                "attribution-text": "© Historic England 2025. Contains Ordnance Survey data © Crown copyright and database right 2025.\nThe Historic England GIS Data contained in this material was obtained on [date].\nThe most publicly available up to date Historic England GIS Data can be obtained from [HistoricEngland.org.uk](https://historicengland.org.uk).",
+                "licence": "ogl3",
+                "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+                "consideration": "scheduled-monuments",
+                "github-discussion": "",
+                "entity-minimum": 13900000,
+                "entity-maximum": 13999999,
+                "phase": "beta",
+                "realm": "dataset",
+                "replacement-dataset": "",
+                "version": "1.0"
+              },
+              "nature.ASNW": {
+                "entry-date": "",
+                "start-date": "",
+                "end-date": "",
+                "collection": "ancient-woodland",
+                "dataset": "ancient-woodland",
+                "description": "An area that’s been wooded continuously since at least 1600 AD",
+                "name": "Ancient woodland",
+                "plural": "Ancient woodlands",
+                "prefix": "",
+                "text": "An area designated as ancient woodland by Natural England.\n\nNatural England and Forestry Commission [Guidance](https://www.gov.uk/guidance/ancient-woodland-and-veteran-trees-protection-surveys-licences)  is used in planning decisions.",
+                "typology": "geography",
+                "wikidata": "Q3078732",
+                "wikipedia": "Ancient_woodland",
+                "entities": "",
+                "themes": [
+                  "environment"
+                ],
+                "entity-count": {
+                  "dataset": "ancient-woodland",
+                  "count": 44373
+                },
+                "paint-options": {
+                  "colour": "#00703c",
+                  "opacity": 0.2
+                },
+                "attribution": "natural-england",
+                "attribution-text": "© Natural England copyright. Contains Ordnance Survey data © Crown copyright and database right 2025.",
+                "licence": "ogl3",
+                "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+                "consideration": "ancient-woodlands",
+                "github-discussion": 32,
+                "entity-minimum": 110000000,
+                "entity-maximum": 129999999,
+                "phase": "live",
+                "realm": "dataset",
+                "replacement-dataset": "",
+                "version": "1.0"
+              },
+              "nature.ramsarSite": {
+                "entry-date": "",
+                "start-date": "",
+                "end-date": "",
+                "collection": "ramsar",
+                "dataset": "ramsar",
+                "description": "",
+                "name": "Ramsar site",
+                "plural": "Ramsar sites",
+                "prefix": "",
+                "text": "An internationally protected site listed as a wetland of international importance.\nRamsar sites are designated by [UNESCO](https://en.unesco.org/) and managed by [Natural England](https://www.gov.uk/government/organisations/natural-england).\n\nNatural England provides [guidance ](https://www.gov.uk/guidance/protected-sites-and-areas-how-to-review-planning-applications) to help local authorities decide on planning applications in protected sites and areas.",
+                "typology": "geography",
+                "wikidata": "",
+                "wikipedia": "",
+                "entities": "",
+                "themes": [
+                  "environment"
+                ],
+                "entity-count": {
+                  "dataset": "ramsar",
+                  "count": 73
+                },
+                "paint-options": {
+                  "colour": "#7fcdff"
+                },
+                "attribution": "natural-england",
+                "attribution-text": "© Natural England copyright. Contains Ordnance Survey data © Crown copyright and database right 2025.",
+                "licence": "ogl3",
+                "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+                "consideration": "ramsar",
+                "github-discussion": 41,
+                "entity-minimum": 612000,
+                "entity-maximum": 619999,
+                "phase": "beta",
+                "realm": "dataset",
+                "replacement-dataset": "",
+                "version": "1.0"
+              },
+              "nature.SAC": {
+                "entry-date": "",
+                "start-date": "",
+                "end-date": "",
+                "collection": "special-area-of-conservation",
+                "dataset": "special-area-of-conservation",
+                "description": "",
+                "name": "Special area of conservation",
+                "plural": "Special areas of conservation",
+                "prefix": "",
+                "text": "Special areas of conservation (SACs) are area of land which have been designated by\n[DEFRA](https://www.gov.uk/government/organisations/department-for-environment-food-rural-affairs),\nwith advice from the [Joint Nature Conservation Committee](https://jncc.gov.uk/),\nto protect specific habitats and species.\n\nDEFRA and [Natural England](https://www.gov.uk/government/organisations/natural-england) publish\n[guidance](https://www.gov.uk/guidance/protected-sites-and-areas-how-to-review-planning-applications)\non how to review planning applications in protected sites and areas.",
+                "typology": "geography",
+                "wikidata": "Q1191622",
+                "wikipedia": "Special_Area_of_Conservation",
+                "entities": "",
+                "themes": [
+                  "environment"
+                ],
+                "entity-count": {
+                  "dataset": "special-area-of-conservation",
+                  "count": 260
+                },
+                "paint-options": {
+                  "colour": "#7A8705"
+                },
+                "attribution": "natural-england",
+                "attribution-text": "© Natural England copyright. Contains Ordnance Survey data © Crown copyright and database right 2025.",
+                "licence": "ogl3",
+                "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+                "consideration": "special-areas-of-conservation",
+                "github-discussion": "",
+                "entity-minimum": 14800000,
+                "entity-maximum": 14899999,
+                "phase": "beta",
+                "realm": "dataset",
+                "replacement-dataset": "",
+                "version": "1.0"
+              },
+              "nature.SPA": {
+                "entry-date": "",
+                "start-date": "",
+                "end-date": "",
+                "collection": "special-protection-area",
+                "dataset": "special-protection-area",
+                "description": "",
+                "name": "Special protection area",
+                "plural": "Special protection areas",
+                "prefix": "",
+                "text": "[Special protection areas](https://naturalengland-defra.opendata.arcgis.com/maps/Defra::special-protection-areas-england/about) is an area designated \nfor the protection of birds and wildlife. This dataset is provided by [Natural England](https://www.gov.uk/government/organisations/natural-england).",
+                "typology": "geography",
+                "wikidata": "",
+                "wikipedia": "",
+                "entities": "",
+                "themes": [
+                  "environment"
+                ],
+                "entity-count": {
+                  "dataset": "special-protection-area",
+                  "count": 88
+                },
+                "paint-options": "",
+                "attribution": "natural-england",
+                "attribution-text": "© Natural England copyright. Contains Ordnance Survey data © Crown copyright and database right 2025.",
+                "licence": "ogl3",
+                "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+                "consideration": "special-protection-areas",
+                "github-discussion": "",
+                "entity-minimum": 14900000,
+                "entity-maximum": 14999999,
+                "phase": "beta",
+                "realm": "dataset",
+                "replacement-dataset": "",
+                "version": "1.0"
+              },
+              "nature.SSSI": {
+                "entry-date": "",
+                "start-date": "",
+                "end-date": "",
+                "collection": "site-of-special-scientific-interest",
+                "dataset": "site-of-special-scientific-interest",
+                "description": "",
+                "name": "Site of special scientific interest",
+                "plural": "Sites of special scientific interest",
+                "prefix": "",
+                "text": "Sites of special scientific interest (SSSI) are nationally protected sites that have features such as wildlife or geology. \n\nSSSIs are designated by [Natural England](https://www.gov.uk/government/organisations/natural-england).\nThere is [guidance](https://www.gov.uk/guidance/protected-areas-sites-of-special-scientific-interest) to help local authorities decide on planning applications in protected SSSIs.",
+                "typology": "geography",
+                "wikidata": "Q422211",
+                "wikipedia": "Site_of_Special_Scientific_Interest",
+                "entities": "",
+                "themes": [
+                  "environment"
+                ],
+                "entity-count": {
+                  "dataset": "site-of-special-scientific-interest",
+                  "count": 4129
+                },
+                "paint-options": {
+                  "colour": "#308fac"
+                },
+                "attribution": "natural-england",
+                "attribution-text": "© Natural England copyright. Contains Ordnance Survey data © Crown copyright and database right 2025.",
+                "licence": "ogl3",
+                "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+                "consideration": "sites-of-special-scientific-interest",
+                "github-discussion": "",
+                "entity-minimum": 14500000,
+                "entity-maximum": 14599999,
+                "phase": "beta",
+                "realm": "dataset",
+                "replacement-dataset": "",
+                "version": "1.0"
+              },
+              "registeredPark": {
+                "entry-date": "",
+                "start-date": "",
+                "end-date": "",
+                "collection": "historic-england",
+                "dataset": "park-and-garden",
+                "description": "",
+                "name": "Historic parks and gardens",
+                "plural": "Parks and gardens",
+                "prefix": "",
+                "text": "Historic parks and gardens as listed by [Historic England](https://historicengland.org.uk/) in the [Register of Parks and Gardens of Special Historic Interest](https://historicengland.org.uk/listing/what-is-designation/registered-parks-and-gardens/).",
+                "typology": "geography",
+                "wikidata": "Q6975250",
+                "wikipedia": "Register_of_Historic_Parks_and_Gardens_of_Special_Historic_Interest_in_England",
+                "entities": "",
+                "themes": [
+                  "environment",
+                  "heritage"
+                ],
+                "entity-count": {
+                  "dataset": "park-and-garden",
+                  "count": 1716
+                },
+                "paint-options": {
+                  "colour": "#0EB951"
+                },
+                "attribution": "historic-england",
+                "attribution-text": "© Historic England 2025. Contains Ordnance Survey data © Crown copyright and database right 2025.\nThe Historic England GIS Data contained in this material was obtained on [date].\nThe most publicly available up to date Historic England GIS Data can be obtained from [HistoricEngland.org.uk](https://historicengland.org.uk).",
+                "licence": "ogl3",
+                "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+                "consideration": "",
+                "github-discussion": "",
+                "entity-minimum": 11100000,
+                "entity-maximum": 11199999,
+                "phase": "beta",
+                "realm": "dataset",
+                "replacement-dataset": "",
+                "version": "1.0"
+              },
+              "tpo": {
+                "entry-date": "",
+                "start-date": "",
+                "end-date": "",
+                "collection": "tree-preservation-order",
+                "dataset": "tree-preservation-zone",
+                "description": "An area covered by a tree preservation order",
+                "name": "Tree preservation zone",
+                "plural": "Trees preservation zones",
+                "prefix": "",
+                "text": "A Tree Preservation Order (TPO) can be placed on single trees, groups of trees and even whole woodlands. Tree Preservation Orders are made by local planning authorities following [guidance](https://www.gov.uk/guidance/tree-preservation-orders-and-trees-in-conservation-areas) provided by the [Ministry of Housing, Communities and Local Governments](https://www.gov.uk/government/organisations/ministry-of-housing-communities-local-government).\n\nEach [tree preservation order](/dataset/tree-preservation-order) may apply to a number of tree preservation order zones, and a number of individual [trees](/dataset/tree).\n\nThis dataset contains data from [a small group of local planning authorities](/about/) who we are working with to develop a [data specification for tree preservation orders](https://www.digital-land.info/guidance/specifications/tree-preservation-order).",
+                "typology": "geography",
+                "wikidata": "Q10884",
+                "wikipedia": "Tree",
+                "entities": "",
+                "themes": [
+                  "environment"
+                ],
+                "entity-count": {
+                  "dataset": "tree-preservation-zone",
+                  "count": 26713
+                },
+                "paint-options": "",
+                "attribution": "crown-copyright",
+                "attribution-text": "© Crown copyright and database right 2025",
+                "licence": "ogl3",
+                "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+                "consideration": "tree-preservation-orders",
+                "github-discussion": 43,
+                "entity-minimum": 19100000,
+                "entity-maximum": 29099999,
+                "phase": "beta",
+                "realm": "dataset",
+                "replacement-dataset": "",
+                "version": "2.0"
+              }
+            },
+            "planxRequest": "https://api.editor.planx.uk/gis/testing?geom=MULTIPOLYGON+%28%28%28-0.076691+51.484197%2C+-0.075933+51.484124%2C+-0.075856+51.484369%2C+-0.075889+51.484372%2C+-0.0759+51.484324%2C+-0.076391+51.484369%2C+-0.076388+51.484383%2C+-0.076644+51.484409%2C+-0.076691+51.484197%29%29%29&vals=article4%2Carticle4.caz%2CbrownfieldSite%2Cdesignated.AONB%2Cdesignated.conservationArea%2CgreenBelt%2Cdesignated.nationalPark%2Cdesignated.nationalPark.broads%2Cdesignated.WHS%2Cflood%2Clisted%2Cmonument%2Cnature.ASNW%2Cnature.ramsarSite%2Cnature.SAC%2Cnature.SPA%2Cnature.SSSI%2CregisteredPark%2Ctpo%2Croad.classified&analytics=false"
+          },
+          {
+            "sourceRequest": "https://api.os.uk/features/v1/wfs?service=WFS&request=GetFeature&version=2.0.0&typeNames=Highways_RoadLink&outputFormat=GEOJSON&srsName=urn%3Aogc%3Adef%3Acrs%3AEPSG%3A%3A4326&count=1&filter=%0A++++%3Cogc%3AFilter%3E%0A++++++%3Cogc%3APropertyIsLike+wildCard%3D%22%25%22+singleChar%3D%22%23%22+escapeChar%3D%22%21%22%3E%0A++++++++%3Cogc%3APropertyName%3EFormsPartOf%3C%2Fogc%3APropertyName%3E%0A++++++++%3Cogc%3ALiteral%3E%25Street%23usrn22500531%25%3C%2Fogc%3ALiteral%3E%0A++++++%3C%2Fogc%3APropertyIsLike%3E%0A++++%3C%2Fogc%3AFilter%3E%0A++&",
+            "metadata": {
+              "road.classified": {
+                "name": "Classified road",
+                "plural": "Classified roads",
+                "text": "This will effect your project if you are looking to add a dropped kerb. It may also impact some agricultural or forestry projects within 25 metres of a classified road."
+              }
+            },
+            "constraints": {
+              "road.classified": {
+                "fn": "road.classified",
+                "value": false,
+                "text": "is not on a Classified Road",
+                "category": "General policy"
+              }
+            },
+            "planxRequest": "https://api.editor.planx.uk/roads?usrn=22500531"
+          }
+        ],
+        "planningConstraints.action": "Accepted all planning constraints",
+        "_nots": {
+          "property.constraints.planning": [
+            "article4",
+            "article4.caz",
+            "article4.buckinghamshire.os262",
+            "article4.gateshead.saltwell.D4",
+            "article4.newcastle.saintPetersBasin3",
+            "brownfieldSite",
+            "designated.AONB",
+            "greenBelt",
+            "designated.nationalPark",
+            "designated.nationalPark.broads",
+            "designated.WHS",
+            "monument",
+            "nature.ASNW",
+            "nature.ramsarSite",
+            "nature.SAC",
+            "nature.SPA",
+            "nature.SSSI",
+            "registeredPark",
+            "listed.grade.I",
+            "listed.grade.II",
+            "listed.grade.II*",
+            "road.classified"
+          ]
+        },
+        "property.constraints.planning": [
+          "listed",
+          "designated.conservationArea",
+          "flood",
+          "tpo",
+          "designated",
+          "flood.zone.2",
+          "flood.zone.3"
+        ]
+      }
+    },
+    "0xIFi1ZhfZ": {
+      "auto": true,
+      "answers": [
+        "5NwXOe2kl6",
+        "1DMLC1ilHg",
+        "S50pYmgKlM"
+      ]
+    },
+    "jtVZ3Xa3DE": {
+      "auto": false,
+      "answers": [
+        "fR27RXqLNn"
+      ]
+    },
+    "wvRHLsZyyk": {
+      "auto": true,
+      "answers": [
+        "0FIHMM1vcO",
+        "x4Zma010vS"
+      ]
+    },
+    "vEr4UyFu4u": {
+      "auto": false,
+      "answers": [
+        "rQ3yeKMo3r"
+      ]
+    },
+    "Z9dOoU0dD1": {
+      "auto": true,
+      "answers": [
+        "6m7kgvL204"
+      ]
+    },
+    "MQzrk4KPRO": {
+      "auto": true,
+      "answers": [
+        "zHeTwH6CaY"
+      ]
+    }
+  },
+};
+
+module.exports = { oldSession };

--- a/jan2025_revisedSessions/tests/sessionData.test.js
+++ b/jan2025_revisedSessions/tests/sessionData.test.js
@@ -1,0 +1,12 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const { migrateSessionData } = require("./../helpers");
+const { oldSession } = require("../tests/mocks/oldSession");
+const { expectedSession } = require("../tests/mocks/expectedSession");
+
+describe("migrate session data function", () => {
+  it("#returns the expected data", () => {
+    const migratedSession = migrateSessionData(oldSession);
+    assert.deepStrictEqual(migratedSession, expectedSession);
+  });
+});


### PR DESCRIPTION
Our original run had a faulty GraphQL `_or` clause that failed to correctly fetch "active" sessions (created in last 28 days, but not submitted yet) - this script updates that query and adjusts the original script to _only_ update sessions associated with a flow (not flow or published flow data as this was all correctly fetched and updated). 

No changes have been made to the `migrateSessionData` helper function, this is additionally all correct originally.